### PR TITLE
Support Linux Chrome DevToolsActivePort path

### DIFF
--- a/skills/chrome-cdp/scripts/cdp.mjs
+++ b/skills/chrome-cdp/scripts/cdp.mjs
@@ -25,7 +25,12 @@ const PAGES_CACHE = '/tmp/cdp-pages.json';
 function sockPath(targetId) { return `${SOCK_PREFIX}${targetId}.sock`; }
 
 function getWsUrl() {
-  const portFile = resolve(homedir(), 'Library/Application Support/Google/Chrome/DevToolsActivePort');
+  const candidates = [
+    resolve(homedir(), 'Library/Application Support/Google/Chrome/DevToolsActivePort'),
+    resolve(homedir(), '.config/google-chrome/DevToolsActivePort'),
+  ];
+  const portFile = candidates.find(path => existsSync(path));
+  if (!portFile) throw new Error(`Could not find DevToolsActivePort file in: ${candidates.join(', ')}`);
   const lines = readFileSync(portFile, 'utf8').trim().split('\n');
   return `ws://127.0.0.1:${lines[0]}${lines[1]}`;
 }


### PR DESCRIPTION
Loving this!

Here a little thing that makes it play nice with Linux

`scripts/cdp.mjs` currently only checks the macOS Chrome profile location for DevToolsActivePort. This adds the standard Linux Chrome path at `~/.config/google-chrome/DevToolsActivePort`