### PR TITLE
Probe Chrome-family DevToolsActivePort locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Clone or copy the `skills/chrome-cdp/` directory wherever your agent loads skill
 
 Navigate to `chrome://inspect/#remote-debugging` and toggle the switch. That's it.
 
+## Compatibility notes
+
+- The CLI now probes additional `DevToolsActivePort` locations for Chrome-family browsers, including Chrome Beta, Chrome for Testing, Chromium, Brave, and Edge.
+
 ## Usage
 
 ```bash

--- a/skills/chrome-cdp/scripts/cdp.mjs
+++ b/skills/chrome-cdp/scripts/cdp.mjs
@@ -24,15 +24,69 @@ const PAGES_CACHE = '/tmp/cdp-pages.json';
 
 function sockPath(targetId) { return `${SOCK_PREFIX}${targetId}.sock`; }
 
-function getWsUrl() {
+function getPortFileCandidates() {
+  const home = homedir();
   const candidates = [
-    resolve(homedir(), 'Library/Application Support/Google/Chrome/DevToolsActivePort'),
-    resolve(homedir(), '.config/google-chrome/DevToolsActivePort'),
-  ];
-  const portFile = candidates.find(path => existsSync(path));
-  if (!portFile) throw new Error(`Could not find DevToolsActivePort file in: ${candidates.join(', ')}`);
+    process.env.CHROME_CDP_PORT_FILE,
+    resolve(home, 'Library/Application Support/Google/Chrome/DevToolsActivePort'),
+    resolve(home, 'Library/Application Support/Google/Chrome/Default/DevToolsActivePort'),
+    resolve(home, 'Library/Application Support/Google/Chrome Beta/DevToolsActivePort'),
+    resolve(home, 'Library/Application Support/Google/Chrome Beta/Default/DevToolsActivePort'),
+    resolve(home, 'Library/Application Support/Google/Chrome for Testing/DevToolsActivePort'),
+    resolve(home, 'Library/Application Support/Google/Chrome for Testing/Default/DevToolsActivePort'),
+    resolve(home, 'Library/Application Support/Chromium/DevToolsActivePort'),
+    resolve(home, 'Library/Application Support/Chromium/Default/DevToolsActivePort'),
+    resolve(home, 'Library/Application Support/BraveSoftware/Brave-Browser/DevToolsActivePort'),
+    resolve(home, 'Library/Application Support/BraveSoftware/Brave-Browser/Default/DevToolsActivePort'),
+    resolve(home, 'Library/Application Support/Microsoft Edge/DevToolsActivePort'),
+    resolve(home, 'Library/Application Support/Microsoft Edge/Default/DevToolsActivePort'),
+    resolve(home, '.config/google-chrome/DevToolsActivePort'),
+    resolve(home, '.config/google-chrome/Default/DevToolsActivePort'),
+    resolve(home, '.config/google-chrome-beta/DevToolsActivePort'),
+    resolve(home, '.config/google-chrome-beta/Default/DevToolsActivePort'),
+    resolve(home, '.config/chromium/DevToolsActivePort'),
+    resolve(home, '.config/chromium/Default/DevToolsActivePort'),
+    resolve(home, '.config/BraveSoftware/Brave-Browser/DevToolsActivePort'),
+    resolve(home, '.config/BraveSoftware/Brave-Browser/Default/DevToolsActivePort'),
+    resolve(home, '.config/microsoft-edge/DevToolsActivePort'),
+    resolve(home, '.config/microsoft-edge/Default/DevToolsActivePort'),
+  ].filter(Boolean);
+  return [...new Set(candidates)];
+}
+
+function readWsUrlFromPortFile(portFile) {
   const lines = readFileSync(portFile, 'utf8').trim().split('\n');
+  if (lines.length < 2 || !lines[0] || !lines[1]) {
+    throw new Error(`Invalid DevToolsActivePort file: ${portFile}`);
+  }
   return `ws://127.0.0.1:${lines[0]}${lines[1]}`;
+}
+
+function getWsUrlCandidates() {
+  const existing = getPortFileCandidates().filter(path => existsSync(path));
+  return existing.map(portFile => ({
+    portFile,
+    wsUrl: readWsUrlFromPortFile(portFile),
+  }));
+}
+
+async function connectToChrome(cdp) {
+  const candidates = getWsUrlCandidates();
+  if (candidates.length === 0) {
+    throw new Error(`Could not find DevToolsActivePort file in: ${getPortFileCandidates().join(', ')}`);
+  }
+
+  const errors = [];
+  for (const { portFile, wsUrl } of candidates) {
+    try {
+      await cdp.connect(wsUrl);
+      return { wsUrl, portFile };
+    } catch (e) {
+      errors.push(`${portFile}: ${e.message}`);
+    }
+  }
+
+  throw new Error(`Could not connect to Chrome via DevToolsActivePort candidates:\n${errors.join('\n')}`);
 }
 
 const sleep = (ms) => new Promise(r => setTimeout(r, ms));
@@ -436,7 +490,7 @@ async function runDaemon(targetId) {
 
   const cdp = new CDP();
   try {
-    await cdp.connect(getWsUrl());
+    await connectToChrome(cdp);
   } catch (e) {
     process.stderr.write(`Daemon: cannot connect to Chrome: ${e.message}\n`);
     process.exit(1);
@@ -756,7 +810,7 @@ async function main() {
     if (!pages) {
       // No daemon running — connect directly (will trigger one Allow)
       const cdp = new CDP();
-      await cdp.connect(getWsUrl());
+      await connectToChrome(cdp);
       pages = await getPages(cdp);
       cdp.close();
     }


### PR DESCRIPTION
## Summary

This expands `DevToolsActivePort` discovery beyond stable Chrome so the CLI can find and connect to additional Chrome-family browsers.

Added candidate paths for:
- Chrome Beta
- Chrome for Testing
- Chromium
- Brave
- Microsoft Edge

Also supports an explicit override via `CHROME_CDP_PORT_FILE`.

## Why

On macOS and Linux, users may run Chrome Beta or another Chrome-family browser instead of stable Chrome. Before this change, the CLI only checked stable Chrome paths, which made those browsers undiscoverable even when remote debugging was enabled.

## Changes

- replace single-path lookup with multi-candidate probing
- validate `DevToolsActivePort` file contents before use
- try available browser WebSocket candidates until one connects
- add a small README compatibility note

## Verified

Tested locally against Chrome Beta on macOS:
- `cdp list`
- `cdp eval <target> "document.title"`

Both succeeded after the discovery change.
