### PR TITLE
feat: browser profile support — list, filter, open in profiles

### DIFF
--- a/skills/chrome-cdp/SKILL.md
+++ b/skills/chrome-cdp/SKILL.md
@@ -5,7 +5,7 @@ description: Interact with local Chromium browser sessions (Chrome, Dia, Brave, 
 
 # Chrome CDP
 
-Lightweight Chrome DevTools Protocol CLI. Connects directly via WebSocket — no Puppeteer, works with 100+ tabs, instant connection. Supports multiple Chromium-based browsers simultaneously.
+Lightweight Chrome DevTools Protocol CLI. Connects directly via WebSocket — no Puppeteer, works with 100+ tabs, instant connection. Supports multiple Chromium-based browsers and profiles simultaneously.
 
 ## Prerequisites
 
@@ -55,6 +55,30 @@ CDP_PORT=9223 scripts/cdp.mjs list
 
 **Multiple agents:** Use `--port` flags directly instead of `use` — the session file is shared.
 
+## Profiles
+
+Browsers can have multiple profiles (e.g., Work, Personal, Glints). All profiles share the same debug port.
+
+```bash
+# List all profiles
+scripts/cdp.mjs --port 9222 profiles
+
+# List shows profile name for each tab
+scripts/cdp.mjs --port 9222 list
+# D8D3BE54  [Work        ]  Example Page  https://example.com
+
+# Filter tabs by profile
+scripts/cdp.mjs --port 9222 list --profile Work
+
+# Open URL in default profile
+scripts/cdp.mjs --port 9222 open "https://example.com"
+
+# Open URL in specific profile
+scripts/cdp.mjs --port 9222 open "https://example.com" --profile "Casual Me"
+```
+
+**Note:** Opening in a specific profile only works if that profile window is already open. CDP cannot switch profiles — the user must open the profile window first via Chrome's profile picker.
+
 ## Commands
 
 All commands use `scripts/cdp.mjs`. The `<target>` is a **unique** targetId prefix from `list`; copy the full prefix shown in the `list` output (for example `6BE827FA`). The CLI rejects ambiguous prefixes.
@@ -62,14 +86,22 @@ All commands use `scripts/cdp.mjs`. The `<target>` is a **unique** targetId pref
 ### List open pages
 
 ```bash
-scripts/cdp.mjs list
+scripts/cdp.mjs list                        # all tabs, all profiles
+scripts/cdp.mjs list --profile Work         # filter by profile
 scripts/cdp.mjs --port 9223 list            # specific browser
+```
+
+### Profiles
+
+```bash
+scripts/cdp.mjs profiles                    # list all browser profiles
 ```
 
 ### Open a new tab
 
 ```bash
-scripts/cdp.mjs open <url>
+scripts/cdp.mjs open <url>                  # default profile
+scripts/cdp.mjs open <url> --profile Work   # specific profile (window must be open)
 ```
 
 ### Take a screenshot

--- a/skills/chrome-cdp/scripts/cdp.mjs
+++ b/skills/chrome-cdp/scripts/cdp.mjs
@@ -24,6 +24,7 @@ const PAGES_CACHE = '/tmp/cdp-pages.json';
 const SESSION_FILE = '/tmp/cdp-session.json';
 
 function masterSockPath(port) { return `/tmp/cdp-master-${port}.sock`; }
+const CONTEXT_MAP_FILE = '/tmp/cdp-context-profiles.json';
 
 // Browser profile paths keyed by short name.
 const BROWSER_PROFILES = {
@@ -95,6 +96,176 @@ function saveSession(browser, port) {
 
 function clearSession() {
   try { unlinkSync(SESSION_FILE); } catch {}
+}
+
+// ---------------------------------------------------------------------------
+// Profile support — reads Chrome's Local State to map profiles
+// ---------------------------------------------------------------------------
+
+// Get the browser data directory for the current browser.
+function getBrowserDataDir() {
+  const key = (gBrowser || 'chrome').toLowerCase();
+  const profile = BROWSER_PROFILES[key];
+  if (!profile) return null;
+  const dir = profile[platform];
+  return dir ? resolve(homedir(), dir) : null;
+}
+
+// Read all profile names from the browser's Local State file.
+// Returns [{dir: "Default", name: "Work"}, {dir: "Profile 2", name: "Casual Me"}, ...]
+function readProfiles() {
+  const dataDir = getBrowserDataDir();
+  if (!dataDir) return [];
+  const localStatePath = resolve(dataDir, 'Local State');
+  try {
+    const state = JSON.parse(readFileSync(localStatePath, 'utf8'));
+    const cache = state?.profile?.info_cache || {};
+    return Object.entries(cache).map(([dir, info]) => ({
+      dir,
+      name: info.name || dir,
+      gaia: info.gaia_name || '',
+    }));
+  } catch { return []; }
+}
+
+// Build/update the browserContextId → profile name mapping.
+// We discover mappings by seeing which contexts exist for pages.
+// Saved to a temp file so it persists across CLI invocations.
+function loadContextMap() {
+  try { return JSON.parse(readFileSync(CONTEXT_MAP_FILE, 'utf8')); }
+  catch { return {}; }
+}
+
+function saveContextMap(map) {
+  writeFileSync(CONTEXT_MAP_FILE, JSON.stringify(map));
+}
+
+// Given pages with browserContextId and the known profiles, try to map contexts to profiles.
+// Only the defaultBrowserContextId gets auto-mapped (via Local State's last_used).
+// Other contexts are discovered via the probe mechanism or stay as "?" until identified.
+function updateContextMap(pages, defaultContextId) {
+  const map = loadContextMap();
+  const profiles = readProfiles();
+
+  // Auto-map unmapped contexts to profiles using last_active_profiles order.
+  // Chrome's chrome://inspect toggle doesn't use "default context" meaningfully,
+  // so we map by matching unmapped contexts to unmapped active profiles in order.
+  const dataDir = getBrowserDataDir();
+  if (dataDir && profiles.length > 0) {
+    try {
+      const state = JSON.parse(readFileSync(resolve(dataDir, 'Local State'), 'utf8'));
+      const lastActive = state?.profile?.last_active_profiles || [];
+      const alreadyMappedNames = new Set(Object.values(map).filter(Boolean));
+
+      // Count pages per context to prioritize (contexts with pages are real profiles)
+      const contextPageCount = {};
+      for (const p of pages) {
+        contextPageCount[p.browserContextId] = (contextPageCount[p.browserContextId] || 0) + 1;
+      }
+
+      // Get unmapped contexts that have pages, sorted by page count desc
+      const unmappedContexts = Object.entries(contextPageCount)
+        .filter(([ctx]) => !map[ctx] || map[ctx] === null)
+        .sort((a, b) => b[1] - a[1])
+        .map(([ctx]) => ctx);
+
+      // Get unmapped active profiles in order
+      const unmappedProfiles = lastActive
+        .map(dir => profiles.find(p => p.dir === dir))
+        .filter(p => p && !alreadyMappedNames.has(p.name));
+
+      // Assign in order: most-tabs context → first unmapped active profile
+      for (let i = 0; i < Math.min(unmappedContexts.length, unmappedProfiles.length); i++) {
+        map[unmappedContexts[i]] = unmappedProfiles[i].name;
+      }
+    } catch {}
+  }
+
+  // Register unknown contexts but don't guess their profile — leave as null
+  const knownContexts = new Set(Object.keys(map));
+  const contextIds = new Set(pages.map(p => p.browserContextId));
+  for (const ctx of contextIds) {
+    if (!knownContexts.has(ctx)) {
+      map[ctx] = null; // unknown — discover via `list --profile` or probe
+    }
+  }
+
+  saveContextMap(map);
+  return map;
+}
+
+// Resolve a profile name or dir to a profile directory.
+function resolveProfileDir(nameOrDir) {
+  const profiles = readProfiles();
+  const lower = nameOrDir.toLowerCase();
+  // Exact match on dir
+  const byDir = profiles.find(p => p.dir.toLowerCase() === lower);
+  if (byDir) return byDir;
+  // Match on name (case-insensitive)
+  const byName = profiles.filter(p => p.name.toLowerCase() === lower);
+  if (byName.length === 1) return byName[0];
+  // Prefix match on name
+  const byPrefix = profiles.filter(p => p.name.toLowerCase().startsWith(lower));
+  if (byPrefix.length === 1) return byPrefix[0];
+  if (byPrefix.length > 1) throw new Error(`Ambiguous profile "${nameOrDir}" — matches: ${byPrefix.map(p => p.name).join(', ')}`);
+  throw new Error(`Unknown profile "${nameOrDir}". Available: ${profiles.map(p => p.name).join(', ')}`);
+}
+
+// Discover which browserContextId belongs to which profile by opening a temp page
+// in a specific profile and seeing what context it gets.
+async function discoverProfileContext(profileDir, port) {
+  const dataDir = getBrowserDataDir();
+  if (!dataDir) throw new Error('Cannot determine browser data directory');
+
+  // Open a temporary page in the target profile
+  const marker = `cdp-profile-probe-${Date.now()}`;
+  const markerUrl = `data:text/html,<title>${marker}</title>`;
+
+  // Use the OS to open Chrome with the specific profile
+  const browserApp = {
+    chrome: 'Google Chrome', brave: 'Brave Browser', edge: 'Microsoft Edge',
+    chromium: 'Chromium', dia: 'Dia', arc: 'Arc',
+  }[(gBrowser || 'chrome').toLowerCase()] || 'Google Chrome';
+
+  spawn('open', ['-na', browserApp, '--args', `--profile-directory=${profileDir}`, markerUrl], {
+    detached: true, stdio: 'ignore',
+  }).unref();
+
+  // Wait for the probe tab to appear, then read its browserContextId
+  const conn = await getOrStartMasterDaemon(port);
+  for (let i = 0; i < 20; i++) {
+    await sleep(500);
+    const resp = await sendCommand(await getOrStartMasterDaemon(port), { cmd: 'list_raw' });
+    if (!resp.ok) continue;
+    const pages = JSON.parse(resp.result);
+    const probe = pages.find(p => p.title === marker || p.url.includes(marker));
+    if (probe) {
+      // Found it — record the mapping
+      const map = loadContextMap();
+      const profiles = readProfiles();
+      const profile = profiles.find(p => p.dir === profileDir);
+      map[probe.browserContextId] = profile?.name || profileDir;
+      saveContextMap(map);
+
+      // Close the probe tab
+      try {
+        await sendCommand(await getOrStartMasterDaemon(port), {
+          cmd: 'evalraw', targetId: probe.targetId,
+          args: ['Target.closeTarget', JSON.stringify({ targetId: probe.targetId })]
+        });
+      } catch {}
+
+      return probe.browserContextId;
+    }
+  }
+  throw new Error(`Could not discover context for profile "${profileDir}" — probe tab didn't appear`);
+}
+
+// Discover the default browserContextId from the master daemon.
+async function getDefaultContextId(port) {
+  const conn = await getOrStartMasterDaemon(port);
+  const resp = await sendCommand(conn, { cmd: 'get_default_context' });
+  return resp.ok ? resp.result : null;
 }
 
 // Discover the WebSocket URL by querying the HTTP endpoint on a given port.
@@ -355,12 +526,18 @@ async function getPages(cdp) {
   return targetInfos.filter(t => t.type === 'page' && !t.url.startsWith('chrome://'));
 }
 
-function formatPageList(pages) {
+function formatPageList(pages, contextMap = null) {
   const prefixLen = getDisplayPrefixLength(pages.map(p => p.targetId));
+  const showProfile = contextMap && Object.values(contextMap).some(v => v);
   return pages.map(p => {
     const id = p.targetId.slice(0, prefixLen).padEnd(prefixLen);
-    const title = p.title.substring(0, 54).padEnd(54);
-    return `${id}  ${title}  ${p.url}`;
+    const profileName = contextMap?.[p.browserContextId];
+    const profileCol = showProfile
+      ? `[${(profileName || '?').substring(0, 12).padEnd(12)}]  `
+      : '';
+    const titleLen = showProfile ? 40 : 54;
+    const title = p.title.substring(0, titleLen).padEnd(titleLen);
+    return `${id}  ${profileCol}${title}  ${p.url}`;
   }).join('\n');
 }
 
@@ -710,10 +887,18 @@ async function runMasterDaemon(port) {
           result = 'Detached';
           break;
         }
+        case 'get_default_context': {
+          const { defaultBrowserContextId } = await cdp.send('Target.getBrowserContexts');
+          result = defaultBrowserContextId || '';
+          break;
+        }
         case 'open': {
-          // Open a new tab
+          // Open a new tab, optionally in a specific browserContextId
           const url = args[0] || 'about:blank';
-          const { targetId: newId } = await cdp.send('Target.createTarget', { url });
+          const browserContextId = args[1] || undefined;
+          const params = { url };
+          if (browserContextId) params.browserContextId = browserContextId;
+          const { targetId: newId } = await cdp.send('Target.createTarget', params);
           result = newId;
           break;
         }
@@ -938,8 +1123,10 @@ Commands:
   use <browser|port>                Set active browser for subsequent commands
                                     e.g. "use dia", "use chrome", "use 9223"
                                     Use "use auto" to clear and auto-discover
-  list                              List open pages (shows unique target prefixes)
-  open <url>                        Open URL in a new tab
+  profiles                          List all browser profiles
+  list [--profile <name>]           List open pages (shows unique target prefixes)
+                                    With --profile, filter to a specific profile
+  open <url> [--profile <name>]     Open URL in a new tab (default profile unless specified)
   snap  <target>                    Accessibility tree snapshot
   eval  <target> <expr>             Evaluate JS expression
   shot  <target> [file]             Screenshot (default: /tmp/screenshot.png); prints coordinate mapping
@@ -1043,35 +1230,144 @@ async function main() {
   // Load saved session (only if no CLI flags or env vars set)
   loadSession();
 
+  // Extract --profile flag from args
+  let gProfile = null;
+  const cleanArgs = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--profile' && i + 1 < args.length) {
+      gProfile = args[++i];
+    } else {
+      cleanArgs.push(args[i]);
+    }
+  }
+
   // Resolve canonical port for master daemon
   const port = await resolvePort();
 
-  // List — route through master daemon
+  // Profiles — list all browser profiles
+  if (cmd === 'profiles') {
+    const profiles = readProfiles();
+    if (profiles.length === 0) {
+      console.log('No profiles found.');
+    } else {
+      // Also show context mapping if available
+      const defaultCtxId = await getDefaultContextId(port).catch(() => null);
+      if (defaultCtxId) updateContextMap([], defaultCtxId);
+      const map = loadContextMap();
+      const reverseMap = {};
+      for (const [ctx, name] of Object.entries(map)) {
+        if (name) reverseMap[name] = ctx;
+      }
+      for (const p of profiles) {
+        const ctx = reverseMap[p.name];
+        const status = ctx ? '●' : '○';
+        const gaiaStr = p.gaia ? ` (${p.gaia})` : '';
+        console.log(`  ${status} ${p.name}${gaiaStr}  [${p.dir}]`);
+      }
+      console.log(`\n  ● = has loaded tabs    ○ = no loaded tabs`);
+    }
+    return;
+  }
+
+  // List — route through master daemon, with optional profile filter
   if (cmd === 'list' || cmd === 'ls') {
     const conn = await getOrStartMasterDaemon(port);
     const resp = await sendCommand(conn, { cmd: 'list_raw' });
     if (!resp.ok) { console.error('Error:', resp.error); process.exit(1); }
-    const pages = JSON.parse(resp.result);
+    let pages = JSON.parse(resp.result);
+
+    // Get default context and update profile mapping
+    const defaultCtxId = await getDefaultContextId(port).catch(() => null);
+    const contextMap = updateContextMap(pages, defaultCtxId);
+
+    // Filter by profile if specified
+    if (gProfile) {
+      const profile = resolveProfileDir(gProfile);
+      const matchingContexts = new Set();
+      for (const [ctx, name] of Object.entries(contextMap)) {
+        if (name === profile.name) matchingContexts.add(ctx);
+      }
+      // If no contexts mapped yet for this profile, try to discover
+      if (matchingContexts.size === 0) {
+        try {
+          const ctx = await discoverProfileContext(profile.dir, port);
+          matchingContexts.add(ctx);
+          // Re-fetch pages after probe
+          const resp2 = await sendCommand(await getOrStartMasterDaemon(port), { cmd: 'list_raw' });
+          if (resp2.ok) pages = JSON.parse(resp2.result);
+        } catch (e) {
+          console.error(`Warning: ${e.message}`);
+        }
+      }
+      if (matchingContexts.size > 0) {
+        pages = pages.filter(p => matchingContexts.has(p.browserContextId));
+      }
+    }
+
     writeFileSync(PAGES_CACHE, JSON.stringify(pages));
-    console.log(formatPageList(pages));
+    console.log(formatPageList(pages, contextMap));
     setTimeout(() => process.exit(0), 100);
     return;
   }
 
-  // Open — create a new tab
+  // Open — create a new tab, optionally in a specific profile
   if (cmd === 'open') {
-    const url = args[0] || 'about:blank';
-    const conn = await getOrStartMasterDaemon(port);
-    const resp = await sendCommand(conn, { cmd: 'open', args: [url] });
-    if (!resp.ok) { console.error('Error:', resp.error); process.exit(1); }
-    console.log(`Opened ${url} (target: ${resp.result})`);
+    const url = cleanArgs[0] || 'about:blank';
+    if (gProfile) {
+      // Open in a specific profile using the OS (-na forces new instance for profile routing)
+      const profile = resolveProfileDir(gProfile);
+      const browserApp = {
+        chrome: 'Google Chrome', brave: 'Brave Browser', edge: 'Microsoft Edge',
+        chromium: 'Chromium', dia: 'Dia', arc: 'Arc',
+      }[(gBrowser || 'chrome').toLowerCase()] || 'Google Chrome';
+
+      // Snapshot contexts before opening
+      const connBefore = await getOrStartMasterDaemon(port);
+      const respBefore = await sendCommand(connBefore, { cmd: 'list_raw' });
+      const contextsBefore = new Set();
+      if (respBefore.ok) {
+        JSON.parse(respBefore.result).forEach(p => contextsBefore.add(p.browserContextId));
+      }
+
+      spawn('open', ['-na', browserApp, '--args', `--profile-directory=${profile.dir}`, url], {
+        detached: true, stdio: 'ignore',
+      }).unref();
+
+      // Wait for the new tab and discover its context
+      for (let i = 0; i < 15; i++) {
+        await sleep(500);
+        const conn2 = await getOrStartMasterDaemon(port);
+        const resp2 = await sendCommand(conn2, { cmd: 'list_raw' });
+        if (!resp2.ok) continue;
+        const pages = JSON.parse(resp2.result);
+        const newPage = pages.find(p => !contextsBefore.has(p.browserContextId) || p.url === url || p.url === url + '/');
+        if (newPage) {
+          // Map the new context to this profile
+          const map = loadContextMap();
+          if (!map[newPage.browserContextId] || map[newPage.browserContextId] === null) {
+            map[newPage.browserContextId] = profile.name;
+            saveContextMap(map);
+          }
+          console.log(`Opened ${url} in profile "${profile.name}" (target: ${newPage.targetId.slice(0,8)})`);
+          setTimeout(() => process.exit(0), 100);
+          return;
+        }
+      }
+      console.log(`Opening ${url} in profile "${profile.name}" (tab may still be loading)`);
+    } else {
+      // Open in default context via CDP
+      const conn = await getOrStartMasterDaemon(port);
+      const resp = await sendCommand(conn, { cmd: 'open', args: [url] });
+      if (!resp.ok) { console.error('Error:', resp.error); process.exit(1); }
+      console.log(`Opened ${url} (target: ${resp.result})`);
+    }
     setTimeout(() => process.exit(0), 100);
     return;
   }
 
   // Stop
   if (cmd === 'stop') {
-    await stopDaemons(args[0]);
+    await stopDaemons(cleanArgs[0]);
     return;
   }
 
@@ -1082,7 +1378,7 @@ async function main() {
     process.exit(1);
   }
 
-  const targetPrefix = args[0];
+  const targetPrefix = cleanArgs[0];
   if (!targetPrefix) {
     console.error('Error: target ID required. Run "cdp list" first.');
     process.exit(1);
@@ -1100,7 +1396,7 @@ async function main() {
   // Connect to master daemon
   const conn = await getOrStartMasterDaemon(port);
 
-  const cmdArgs = args.slice(1);
+  const cmdArgs = cleanArgs.slice(1);
 
   if (cmd === 'eval') {
     const expr = cmdArgs.join(' ');


### PR DESCRIPTION
## Summary

- Add browser profile awareness — `profiles` command lists all Chrome/Chromium profiles (Work, Personal, etc.)
- `list` shows `[Profile Name]` column for each tab when profiles are detected
- `list --profile Work` filters tabs to a specific profile
- `open <url> --profile Work` opens a URL in a specific profile's window
- Auto-discovery of browserContextId → profile mapping via Chrome's Local State file

**Depends on:** #8 (multi-browser support), which depends on #7 (master daemon)

## How it works

Chrome/Chromium browsers store profile metadata in a `Local State` JSON file in their data directory. Each profile has a directory name (e.g., `Default`, `Profile 2`) and a display name (e.g., `Work`, `Casual Me`).

The challenge is mapping CDP's `browserContextId` (an opaque UUID) to profile names. This PR solves it with a multi-layer approach:

1. **Auto-mapping via `last_active_profiles`** — Chrome's Local State tracks which profile directories were recently active. We match these to unmapped browserContextIds by sorting contexts by page count (most-tabs context = most-active profile).

2. **Probe discovery** — When `--profile` targets a profile with no known contextId, we open a temporary marker page (`data:text/html,<title>cdp-probe-...</title>`) in that profile using `open -na`, wait for it to appear in the tab list, read its browserContextId, then close the probe tab.

3. **Persistent mapping** — Context→profile mappings are saved to `/tmp/cdp-context-profiles.json` so they survive across CLI invocations.

The `open --profile` command uses macOS's `open -na` with `--profile-directory` to route the URL to the correct profile's window. This requires the target profile window to already be open.

## Testing

- [ ] `cdp profiles` — lists all browser profiles with active (loaded tabs) indicator
- [ ] `cdp list` — shows `[Profile Name]` column when multiple profiles have tabs
- [ ] `cdp list --profile Work` — filters to only Work profile's tabs
- [ ] `cdp open https://example.com --profile Work` — opens in Work profile's window
- [ ] Profile auto-discovery — first `list` after starting correctly maps contexts to names
- [ ] Probe discovery — `list --profile <unmapped>` opens probe tab, discovers context, closes probe
- [ ] Single profile — no `[Profile]` column shown when only one profile has tabs
- [ ] Profile prefix matching — `--profile Wo` resolves to `Work`
- [ ] Ambiguous profile — clear error message when prefix matches multiple profiles