### PR TITLE
fix: support Linux browsers and CDP_PORT_FILE env var in getWsUrl

### DIFF
--- a/skills/chrome-cdp/scripts/cdp.mjs
+++ b/skills/chrome-cdp/scripts/cdp.mjs
@@ -25,14 +25,15 @@ const PAGES_CACHE = '/tmp/cdp-pages.json';
 function sockPath(targetId) { return `${SOCK_PREFIX}${targetId}.sock`; }
 
 function getWsUrl() {
-  const candidates = [
-    resolve(homedir(), 'Library/Application Support/Google/Chrome/DevToolsActivePort'),
-    resolve(homedir(), '.config/google-chrome/DevToolsActivePort'),
-  ];
-  const portFile = candidates.find(path => existsSync(path));
-  if (!portFile) throw new Error(`Could not find DevToolsActivePort file in: ${candidates.join(', ')}`);
-  const lines = readFileSync(portFile, 'utf8').trim().split('\n');
-  return `ws://127.0.0.1:${lines[0]}${lines[1]}`;
+  const home = homedir();
+  const f = [
+    process.env.CDP_PORT_FILE,
+    ...['vivaldi-snapshot', 'vivaldi', 'google-chrome', 'chromium'].map(b => `${home}/.config/${b}/DevToolsActivePort`),
+    `${home}/Library/Application Support/Google/Chrome/DevToolsActivePort`,
+  ].filter(Boolean).find(existsSync);
+  if (!f) throw new Error('No DevToolsActivePort. Enable remote debugging at chrome://inspect/#remote-debugging');
+  const [port, path] = readFileSync(f, 'utf8').trim().split('\n');
+  return `ws://127.0.0.1:${port}${path}`;
 }
 
 const sleep = (ms) => new Promise(r => setTimeout(r, ms));


### PR DESCRIPTION
Extends #1 (Linux Chrome) to also cover Vivaldi snapshot/stable and Chromium.

Linux browsers store `DevToolsActivePort` under `~/.config/<browser>/`. Generate all common paths from an array of browser names instead of listing each one explicitly, with a `CDP_PORT_FILE` env var override for non-standard setups, then fall back to the original macOS Chrome path.

```js
const f = [
  process.env.CDP_PORT_FILE,
  ...['vivaldi-snapshot', 'vivaldi', 'google-chrome', 'chromium'].map(b => `${home}/.config/${b}/DevToolsActivePort`),
  `${home}/Library/Application Support/Google/Chrome/DevToolsActivePort`,
].filter(Boolean).find(existsSync);
```

Tested on Ubuntu 24.04 with Vivaldi Snapshot 7.9 (Chromium 146).