### PR TITLE
Harden chrome-cdp daemon runtime and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Let your AI agent see and interact with your **live Chrome session** — the tabs you already have open, your logged-in accounts, your current page state. No browser automation framework, no separate browser instance, no re-login.
 
-Works out of the box with any Chrome installation. One toggle to enable, nothing else to install.
+Works with normal Chrome. Turn on Chrome remote debugging once, then your agent can inspect and interact with the tabs you already have open.
 
 ## Why this matters
 
@@ -11,6 +11,27 @@ Most browser automation tools launch a fresh, isolated browser. This one connect
 - Read pages you're logged into (Gmail, GitHub, internal tools, ...)
 - Interact with tabs you're actively working in
 - See the actual state of a page mid-workflow, not a clean reload
+
+## Quick start
+
+1. Install the skill.
+2. In Chrome, open `chrome://inspect/#remote-debugging` and turn on remote debugging.
+3. Open Codex, Claude Code, or another agent that can use this skill.
+4. Ask the agent to use your current Chrome tabs.
+
+Example prompts:
+
+- "Use the chrome-cdp skill and list my open Chrome tabs."
+- "Use chrome-cdp to inspect the current page in my open Chrome tab."
+- "Use chrome-cdp to click the Save button in the tab I already have open."
+- "Use chrome-cdp to take a screenshot of my current tab."
+- "Use chrome-cdp to navigate the current tab to https://example.com."
+
+The agent handles the skill details for you. In normal use, you do not need to
+know or run the underlying script yourself.
+
+If Chrome shows an "Allow debugging" prompt the first time, approve it for the
+tab you want the agent to use.
 
 ## Installation
 
@@ -26,34 +47,111 @@ Clone or copy the `skills/chrome-cdp/` directory wherever your agent loads skill
 
 ### Enable remote debugging in Chrome
 
-Navigate to `chrome://inspect/#remote-debugging` and toggle the switch. That's it.
+Open `chrome://inspect/#remote-debugging` in Chrome and turn the switch on.
 
-## Usage
+The first time a tab is accessed, Chrome may show an "Allow debugging" prompt. Approve it for tabs you want the agent to use.
 
-```bash
-scripts/cdp.mjs list                              # list open tabs
-scripts/cdp.mjs shot   <target>                   # screenshot → /tmp/screenshot.png
-scripts/cdp.mjs snap   <target>                   # accessibility tree (compact, semantic)
-scripts/cdp.mjs html   <target> [".selector"]     # full HTML or scoped to CSS selector
-scripts/cdp.mjs eval   <target> "expression"      # evaluate JS in page context
-scripts/cdp.mjs nav    <target> https://...       # navigate and wait for load
-scripts/cdp.mjs net    <target>                   # network resource timing
-scripts/cdp.mjs click  <target> "selector"        # click element by CSS selector
-scripts/cdp.mjs clickxy <target> <x> <y>          # click at CSS pixel coordinates
-scripts/cdp.mjs type   <target> "text"            # type at focused element (works in cross-origin iframes)
-scripts/cdp.mjs loadall <target> "selector"       # click "load more" until gone
-scripts/cdp.mjs evalraw <target> <method> [json]  # raw CDP command passthrough
-scripts/cdp.mjs stop   [target]                   # stop daemon(s)
-```
+## What the skill can do
 
-`<target>` is a unique prefix of the targetId shown by `list`.
+- Read what is on the current page
+- Save a screenshot
+- Click buttons, links, and other elements
+- Type into the currently focused field
+- Navigate the current tab to another URL
+- Inspect network timing information
+- Run page JavaScript or raw CDP commands in advanced cases
+
+Example prompts:
+
+- "Use chrome-cdp to list my open tabs."
+- "Use chrome-cdp to inspect the current page."
+- "Use chrome-cdp to click the Continue button in my open Chrome tab."
+- "Use chrome-cdp to type into the currently focused field."
+- "Use chrome-cdp to take a screenshot."
+- "Use chrome-cdp to navigate my current tab to https://example.com."
+- "Use chrome-cdp to show network timings for the current page."
+
+## Why this skill exists
+
+This skill is built for live agent work against the Chrome session you already use.
+
+Compared to tools that reconnect on every command, `chrome-cdp` keeps one small background helper per tab. That matters because:
+
+- Chrome asks for debugging approval only once per tab, not over and over
+- Commands are faster after the first attach
+- It works better when you have many tabs open
+
+Internally it talks directly to Chrome DevTools Protocol over Chrome's debugging socket. You usually do not need to care about those details unless you are extending the skill.
 
 ## Why not chrome-devtools-mcp?
 
-[chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp) reconnects on every command, so Chrome's "Allow debugging" modal can re-appear repeatedly and target enumeration times out with many tabs open. `chrome-cdp` holds one persistent daemon per tab — the modal fires once, and it handles 100+ tabs reliably.
+[chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp) is relevant comparison because it solves a similar problem.
 
-## How it works
+The main difference is connection style:
 
-Connects directly to Chrome's remote debugging WebSocket — no Puppeteer, no intermediary. On first access to a tab, a lightweight background daemon is spawned that holds the session open. Chrome's "Allow debugging" modal appears once per tab; subsequent commands reuse the daemon silently. Daemons auto-exit after 20 minutes of inactivity.
+- `chrome-devtools-mcp` reconnects on each command
+- `chrome-cdp` keeps one small background daemon per tab
 
-This approach is also why it handles 100+ open tabs reliably, where tools built on Puppeteer often time out during target enumeration.
+Why that matters in practice:
+
+- Chrome asks for debugging approval once per tab instead of over and over
+- Follow-up commands are faster after the first attach
+- It behaves better when you have many tabs open
+
+## Security model
+
+`chrome-cdp` is a local-user tool. Once you approve Chrome debugging for a tab, this tool can act with that tab's full session state, including logged-in content and privileged workflows.
+
+In plain terms:
+
+- Files are kept in a private per-user runtime directory instead of global `/tmp`
+- Daemon socket names are random, not predictable
+- Only the current user can read the cache and daemon metadata files
+- Every daemon request needs a session token
+
+### `--allow-unsafe`
+
+Most users do **not** need this.
+
+You only need unsafe mode when you explicitly want the agent to:
+
+- run JavaScript in the page
+- send raw CDP commands
+
+Examples:
+
+- "Use chrome-cdp in unsafe mode and run `document.title` in the current page."
+- "Use chrome-cdp in unsafe mode and send a raw CDP command."
+
+If you maintain the skill or wrapper yourself, unsafe mode maps to the
+underlying `--allow-unsafe` flag. Leave it off for normal reading, clicking,
+typing, navigation, and screenshots.
+
+Use it only for trusted flows. These commands can run arbitrary page JavaScript or raw CDP methods against your live Chrome tab.
+
+This makes the local setup safer, but it is not a full sandbox. If something already runs as your user, it may still be able to use the Chrome session you approved. The main improvement is simple: no predictable `/tmp` paths and no unauthenticated local daemon access.
+
+## For maintainers and manual debugging
+
+Most users can ignore this section.
+
+The skill is backed by `scripts/cdp.mjs`. If you are debugging the skill itself
+from a terminal, these are the underlying commands:
+
+```bash
+scripts/cdp.mjs list                              # list open tabs
+scripts/cdp.mjs shot   <target>                   # screenshot -> private runtime path
+scripts/cdp.mjs snap   <target>                   # accessibility tree
+scripts/cdp.mjs html   <target> [".selector"]     # full HTML or scoped HTML
+scripts/cdp.mjs --allow-unsafe eval <target> "expression"
+scripts/cdp.mjs nav    <target> https://...       # navigate and wait for load
+scripts/cdp.mjs net    <target>                   # network timing
+scripts/cdp.mjs click  <target> "selector"        # click element by selector
+scripts/cdp.mjs clickxy <target> <x> <y>          # click at CSS pixel coordinates
+scripts/cdp.mjs type   <target> "text"            # type at focused element
+scripts/cdp.mjs loadall <target> "selector"       # click "load more" until gone
+scripts/cdp.mjs --allow-unsafe evalraw <target> <method> [json]
+scripts/cdp.mjs stop   [target]                   # stop daemon(s)
+```
+
+`<target>` is a unique prefix of the target id shown by `list`.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "devtools"
   ],
   "license": "MIT",
+  "scripts": {
+    "test": "node --test skills/chrome-cdp/scripts/cdp.test.mjs"
+  },
   "files": [
     "skills/",
     "README.md"

--- a/skills/chrome-cdp/scripts/cdp.mjs
+++ b/skills/chrome-cdp/scripts/cdp.mjs
@@ -7,11 +7,23 @@
 // the CDP session open. Chrome's "Allow debugging" modal fires once per
 // daemon (= once per tab). Daemons auto-exit after 20min idle.
 
-import { readFileSync, writeFileSync, unlinkSync, existsSync, readdirSync } from 'fs';
-import { homedir } from 'os';
-import { resolve } from 'path';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'fs';
 import { spawn } from 'child_process';
+import { randomBytes } from 'crypto';
 import net from 'net';
+import { homedir, platform, tmpdir } from 'os';
+import { basename, dirname, join, resolve } from 'path';
+import { pathToFileURL } from 'url';
 
 const TIMEOUT = 15000;
 const NAVIGATION_TIMEOUT = 30000;
@@ -19,11 +31,276 @@ const IDLE_TIMEOUT = 20 * 60 * 1000;
 const DAEMON_CONNECT_RETRIES = 20;
 const DAEMON_CONNECT_DELAY = 300;
 const MIN_TARGET_PREFIX_LEN = 8;
-const SOCK_PREFIX = '/tmp/cdp-';
-const PAGES_CACHE = '/tmp/cdp-pages.json';
+const SOCKET_MODE = 0o600;
+const FILE_MODE = 0o600;
+const DIR_MODE = 0o700;
+const ALLOW_UNSAFE_ENV = 'CDP_ALLOW_UNSAFE';
 
-function sockPath(targetId) { return `${SOCK_PREFIX}${targetId}.sock`; }
+process.umask(0o077);
 
+const RUNTIME_ROOT = initRuntimeRoot();
+const PAGES_CACHE = join(RUNTIME_ROOT, 'pages.json');
+const DAEMONS_DIR = join(RUNTIME_ROOT, 'daemons');
+// Test-only hooks that let the unit tests fake socket classification,
+// connections, and process spawning without affecting production behavior.
+const testHooks = {
+  isSocketFile: null,
+  connectToSocket: null,
+  spawn: null,
+};
+
+// Prefer an OS-specific private runtime directory, but fall back to a
+// per-user tmpdir location when the preferred path is unavailable.
+function runtimeRootCandidates() {
+  const candidates = [];
+  const xdgRuntimeDir = process.env.XDG_RUNTIME_DIR;
+  if (xdgRuntimeDir) candidates.push(join(xdgRuntimeDir, 'chrome-cdp'));
+  if (platform() === 'darwin') candidates.push(resolve(homedir(), 'Library/Caches/chrome-cdp/runtime'));
+  const uid = typeof process.getuid === 'function' ? process.getuid() : basename(homedir()) || 'user';
+  candidates.push(resolve(tmpdir(), `chrome-cdp-${uid}`));
+  return candidates;
+}
+
+function initRuntimeRoot() {
+  const errors = [];
+  for (const candidate of runtimeRootCandidates()) {
+    try {
+      ensurePrivateDir(candidate);
+      return candidate;
+    } catch (error) {
+      errors.push(`${candidate}: ${error.message}`);
+    }
+  }
+  throw new Error(`Unable to create a private runtime directory. Tried: ${errors.join('; ')}`);
+}
+
+function randomHex(bytes = 16) {
+  return randomBytes(bytes).toString('hex');
+}
+
+// Runtime files are created with owner-only permissions so daemon metadata and
+// tokens are not exposed through world-readable temp files.
+function ensurePrivateDir(dirPath) {
+  mkdirSync(dirPath, { recursive: true, mode: DIR_MODE });
+  chmodSync(dirPath, DIR_MODE);
+  const stats = statSync(dirPath);
+  if (!stats.isDirectory()) throw new Error(`Runtime path is not a directory: ${dirPath}`);
+  if ((stats.mode & 0o777) !== DIR_MODE) {
+    throw new Error(`Runtime directory must be owner-only (0700): ${dirPath}`);
+  }
+}
+
+function ensurePrivateFile(filePath) {
+  if (!existsSync(filePath)) return;
+  chmodSync(filePath, FILE_MODE);
+  const stats = statSync(filePath);
+  if ((stats.mode & 0o777) !== FILE_MODE) {
+    throw new Error(`Runtime file must be owner-only (0600): ${filePath}`);
+  }
+}
+
+function writePrivateFile(filePath, content) {
+  ensurePrivateDir(dirname(filePath));
+  const tempPath = `${filePath}.${process.pid}.${randomHex(4)}.tmp`;
+  writeFileSync(tempPath, content, { mode: FILE_MODE });
+  chmodSync(tempPath, FILE_MODE);
+  renameSync(tempPath, filePath);
+  ensurePrivateFile(filePath);
+}
+
+function writePrivateJson(filePath, value) {
+  writePrivateFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+// The runtime root contains cache files plus a per-daemon metadata directory.
+function ensureRuntimeRoot() {
+  ensurePrivateDir(RUNTIME_ROOT);
+  ensurePrivateDir(DAEMONS_DIR);
+}
+
+function readJsonFile(filePath, fallback) {
+  try {
+    if (!existsSync(filePath)) return fallback;
+    const raw = readFileSync(filePath, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+function isWithinDir(filePath, dirPath) {
+  if (!filePath || !dirPath) return false;
+  const resolvedDir = `${resolve(dirPath)}/`;
+  const resolvedPath = resolve(filePath);
+  return resolvedPath.startsWith(resolvedDir);
+}
+
+function isSocketFile(filePath) {
+  if (testHooks.isSocketFile) return testHooks.isSocketFile(filePath);
+  try {
+    return statSync(filePath).isSocket();
+  } catch {
+    return false;
+  }
+}
+
+function safeRemoveRuntimeSocket(socketPath) {
+  if (!isWithinDir(socketPath, RUNTIME_ROOT)) {
+    return { removed: false, reason: 'outside_runtime_root' };
+  }
+  if (!isSocketFile(socketPath)) {
+    // Intentionally leave non-socket files in place even if they share the
+    // same pathname. Safety is preferred over aggressive cleanup here.
+    return { removed: false, reason: 'not_socket' };
+  }
+  try {
+    unlinkSync(socketPath);
+    return { removed: true, reason: 'removed_socket' };
+  } catch {
+    return { removed: false, reason: 'unlink_failed' };
+  }
+}
+
+function safeRemoveDaemonMetadata(metadataPath) {
+  if (!isWithinDir(metadataPath, DAEMONS_DIR)) {
+    return { removed: false, reason: 'outside_daemons_dir' };
+  }
+  try {
+    unlinkSync(metadataPath);
+    return { removed: true, reason: 'removed_metadata' };
+  } catch {
+    return { removed: false, reason: 'unlink_failed' };
+  }
+}
+
+function daemonMetadataPath(daemonId) {
+  return join(DAEMONS_DIR, `${daemonId}.json`);
+}
+
+// Each daemon keeps its own metadata file so concurrent daemon starts/stops do
+// not contend on a shared index file.
+function readDaemonMetadata(metadataPath) {
+  const entry = readJsonFile(metadataPath, null);
+  if (!entry || typeof entry !== 'object') return null;
+  const { daemonId, targetId, socketPath, token, createdAt } = entry;
+  if (!daemonId || !targetId || !socketPath || !token || !createdAt) return null;
+  return {
+    daemonId,
+    targetId,
+    socketPath,
+    token,
+    createdAt,
+    metadataPath,
+  };
+}
+
+function listDaemonMetadataFiles() {
+  ensureRuntimeRoot();
+  return readdirSync(DAEMONS_DIR)
+    .filter(name => name.endsWith('.json'))
+    .map(name => join(DAEMONS_DIR, name));
+}
+
+function writeDaemonMetadata(entry) {
+  writePrivateJson(entry.metadataPath, {
+    daemonId: entry.daemonId,
+    targetId: entry.targetId,
+    socketPath: entry.socketPath,
+    token: entry.token,
+    createdAt: entry.createdAt,
+  });
+}
+
+function discoverDaemonEntries() {
+  // Discovery is intentionally read-only. It classifies daemon metadata into
+  // valid, invalid, and stale buckets; cleanup happens in a separate step.
+  const valid = [];
+  const invalidMetadata = [];
+  const stale = [];
+
+  for (const metadataPath of listDaemonMetadataFiles()) {
+    const entry = readDaemonMetadata(metadataPath);
+    if (!entry) {
+      invalidMetadata.push({ metadataPath, reason: 'invalid_metadata' });
+      continue;
+    }
+    if (!isWithinDir(entry.socketPath, RUNTIME_ROOT)) {
+      stale.push({ entry, reason: 'socket_outside_runtime_root' });
+      continue;
+    }
+    if (!existsSync(entry.socketPath)) {
+      stale.push({ entry, reason: 'socket_missing' });
+      continue;
+    }
+    if (!isSocketFile(entry.socketPath)) {
+      stale.push({ entry, reason: 'socket_path_is_not_a_socket' });
+      continue;
+    }
+    valid.push(entry);
+  }
+
+  return { valid, invalidMetadata, stale };
+}
+
+function cleanupInvalidDaemonMetadata(entries) {
+  return entries.map(({ metadataPath, reason }) => ({
+    type: 'invalid_metadata',
+    reason,
+    metadataPath,
+    metadataResult: safeRemoveDaemonMetadata(metadataPath),
+  }));
+}
+
+function cleanupStaleDaemonEntries(entries) {
+  return entries.map(({ entry, reason }) => ({
+    type: 'stale_daemon',
+    reason,
+    daemonId: entry.daemonId,
+    metadataPath: entry.metadataPath,
+    socketPath: entry.socketPath,
+    socketResult: safeRemoveRuntimeSocket(entry.socketPath),
+    metadataResult: safeRemoveDaemonMetadata(entry.metadataPath),
+  }));
+}
+
+function listDaemonSockets() {
+  const discovered = discoverDaemonEntries();
+  cleanupInvalidDaemonMetadata(discovered.invalidMetadata);
+  cleanupStaleDaemonEntries(discovered.stale);
+  return discovered.valid;
+}
+
+function createDaemonSession(targetId) {
+  ensureRuntimeRoot();
+  const daemonId = randomHex(8);
+  const entry = {
+    daemonId,
+    targetId,
+    socketPath: join(RUNTIME_ROOT, `daemon-${daemonId}.sock`),
+    token: randomHex(24),
+    createdAt: new Date().toISOString(),
+    metadataPath: daemonMetadataPath(daemonId),
+  };
+  writeDaemonMetadata(entry);
+  return entry;
+}
+
+function removeDaemonSession(entry) {
+  if (!entry) return { socketResult: { removed: false, reason: 'missing_entry' }, metadataResult: { removed: false, reason: 'missing_entry' } };
+  // Metadata should always be removed for a dead daemon entry. The socket path
+  // is only removed when it is still a real Unix socket inside the runtime dir.
+  return {
+    socketResult: safeRemoveRuntimeSocket(entry.socketPath),
+    metadataResult: safeRemoveDaemonMetadata(entry.metadataPath),
+  };
+}
+
+function defaultScreenshotPath() {
+  ensureRuntimeRoot();
+  return join(RUNTIME_ROOT, `screenshot-${Date.now()}-${randomHex(4)}.png`);
+}
+
+// Chrome exposes the active DevTools endpoint through DevToolsActivePort.
 function getWsUrl() {
   const candidates = [
     resolve(homedir(), 'Library/Application Support/Google/Chrome/DevToolsActivePort'),
@@ -36,15 +313,6 @@ function getWsUrl() {
 }
 
 const sleep = (ms) => new Promise(r => setTimeout(r, ms));
-
-function listDaemonSockets() {
-  return readdirSync('/tmp')
-    .filter(f => f.startsWith('cdp-') && f.endsWith('.sock'))
-    .map(f => ({
-      targetId: f.slice(4, -5),
-      socketPath: `/tmp/${f}`,
-    }));
-}
 
 function resolvePrefix(prefix, candidates, noun = 'target', missingHint = '') {
   const upper = prefix.toUpperCase();
@@ -68,10 +336,6 @@ function getDisplayPrefixLength(targetIds) {
   }
   return maxLen;
 }
-
-// ---------------------------------------------------------------------------
-// CDP WebSocket client
-// ---------------------------------------------------------------------------
 
 class CDP {
   #ws; #id = 0; #pending = new Map(); #eventHandlers = new Map(); #closeHandlers = [];
@@ -255,7 +519,7 @@ async function evalStr(cdp, sid, expression) {
 }
 
 async function shotStr(cdp, sid, filePath) {
-  // Get device scale factor so we can report coordinate mapping
+  // Get device scale factor so we can report coordinate mapping.
   let dpr = 1;
   try {
     const metrics = await cdp.send('Page.getLayoutMetrics', {}, sid);
@@ -264,12 +528,12 @@ async function shotStr(cdp, sid, filePath) {
         ? Math.round((metrics.visualViewport.clientWidth / metrics.cssVisualViewport.clientWidth) * 100) / 100
         : 1
       : 1;
-    // Simpler: deviceScaleFactor is on the root Page metrics
     const { deviceScaleFactor } = await cdp.send('Emulation.getDeviceMetricsOverride', {}, sid).catch(() => ({}));
     if (deviceScaleFactor) dpr = deviceScaleFactor;
   } catch {}
-  // Fallback: try to get DPR from JS
   if (dpr === 1) {
+    // Fallback: ask the page for devicePixelRatio if the CDP metrics path does
+    // not provide a usable answer.
     try {
       const raw = await evalStr(cdp, sid, 'window.devicePixelRatio');
       const parsed = parseFloat(raw);
@@ -278,8 +542,9 @@ async function shotStr(cdp, sid, filePath) {
   }
 
   const { data } = await cdp.send('Page.captureScreenshot', { format: 'png' }, sid);
-  const out = filePath || '/tmp/screenshot.png';
-  writeFileSync(out, Buffer.from(data, 'base64'));
+  const out = filePath || defaultScreenshotPath();
+  writeFileSync(out, Buffer.from(data, 'base64'), { mode: FILE_MODE });
+  ensurePrivateFile(out);
 
   const lines = [out];
   lines.push(`Screenshot saved. Device pixel ratio (DPR): ${dpr}`);
@@ -287,7 +552,7 @@ async function shotStr(cdp, sid, filePath) {
   lines.push(`  Screenshot pixels → CSS pixels (for CDP Input events): divide by ${dpr}`);
   lines.push(`  e.g. screenshot point (${Math.round(100 * dpr)}, ${Math.round(200 * dpr)}) → CSS (100, 200) → use clickxy <target> 100 200`);
   if (dpr !== 1) {
-    lines.push(`  On this ${dpr}x display: CSS px = screenshot px / ${dpr} ≈ screenshot px × ${Math.round(100/dpr)/100}`);
+    lines.push(`  On this ${dpr}x display: CSS px = screenshot px / ${dpr} ≈ screenshot px × ${Math.round(100 / dpr) / 100}`);
   }
   return lines.join('\n');
 }
@@ -295,7 +560,7 @@ async function shotStr(cdp, sid, filePath) {
 async function htmlStr(cdp, sid, selector) {
   const expr = selector
     ? `document.querySelector(${JSON.stringify(selector)})?.outerHTML || 'Element not found'`
-    : `document.documentElement.outerHTML`;
+    : 'document.documentElement.outerHTML';
   return evalStr(cdp, sid, expr);
 }
 
@@ -350,7 +615,6 @@ async function netStr(cdp, sid) {
   ).join('\n');
 }
 
-// Click element by CSS selector
 async function clickStr(cdp, sid, selector) {
   if (!selector) throw new Error('CSS selector required');
   const expr = `
@@ -363,13 +627,13 @@ async function clickStr(cdp, sid, selector) {
     })()
   `;
   const result = await evalStr(cdp, sid, expr);
-  const r = JSON.parse(result);
-  if (!r.ok) throw new Error(r.error);
-  return `Clicked <${r.tag}> "${r.text}"`;
+  const parsed = JSON.parse(result);
+  if (!parsed.ok) throw new Error(parsed.error);
+  return `Clicked <${parsed.tag}> "${parsed.text}"`;
 }
 
-// Click at CSS pixel coordinates using Input.dispatchMouseEvent
 async function clickXyStr(cdp, sid, x, y) {
+  // Click at CSS pixel coordinates using Input.dispatchMouseEvent.
   const cx = parseFloat(x);
   const cy = parseFloat(y);
   if (isNaN(cx) || isNaN(cy)) throw new Error('x and y must be numbers (CSS pixels)');
@@ -381,22 +645,22 @@ async function clickXyStr(cdp, sid, x, y) {
   return `Clicked at CSS (${cx}, ${cy})`;
 }
 
-// Type text using Input.insertText (works in cross-origin iframes, unlike eval)
 async function typeStr(cdp, sid, text) {
+  // Input.insertText works in cross-origin iframes where eval-driven typing
+  // would fail.
   if (text == null || text === '') throw new Error('text required');
   await cdp.send('Input.insertText', { text }, sid);
   return `Typed ${text.length} characters`;
 }
 
-// Load-more: repeatedly click a button/selector until it disappears
 async function loadAllStr(cdp, sid, selector, intervalMs = 1500) {
+  // Repeatedly click a "load more" control until it disappears or a hard cap
+  // is reached.
   if (!selector) throw new Error('CSS selector required');
   let clicks = 0;
-  const deadline = Date.now() + 5 * 60 * 1000; // 5-minute hard cap
+  const deadline = Date.now() + 5 * 60 * 1000;
   while (Date.now() < deadline) {
-    const exists = await evalStr(cdp, sid,
-      `!!document.querySelector(${JSON.stringify(selector)})`
-    );
+    const exists = await evalStr(cdp, sid, `!!document.querySelector(${JSON.stringify(selector)})`);
     if (exists !== 'true') break;
     const clickExpr = `
       (function() {
@@ -415,8 +679,9 @@ async function loadAllStr(cdp, sid, selector, intervalMs = 1500) {
   return `Clicked "${selector}" ${clicks} time(s) until it disappeared`;
 }
 
-// Send a raw CDP command and return the result as JSON
 async function evalRawStr(cdp, sid, method, paramsJson) {
+  // Raw CDP passthrough stays available for advanced cases, but the CLI gates
+  // access behind --allow-unsafe before requests reach the daemon.
   if (!method) throw new Error('CDP method required (e.g. "DOM.getDocument")');
   let params = {};
   if (paramsJson) {
@@ -427,18 +692,18 @@ async function evalRawStr(cdp, sid, method, paramsJson) {
   return JSON.stringify(result, null, 2);
 }
 
-// ---------------------------------------------------------------------------
-// Per-tab daemon
-// ---------------------------------------------------------------------------
+async function runDaemon(targetId, daemonId, socketPath, token, metadataPath) {
+  ensureRuntimeRoot();
+  safeRemoveRuntimeSocket(socketPath);
 
-async function runDaemon(targetId) {
-  const sp = sockPath(targetId);
-
+  // The daemon owns one attached CDP session for one tab and serves commands
+  // over a local authenticated Unix socket.
   const cdp = new CDP();
   try {
     await cdp.connect(getWsUrl());
   } catch (e) {
     process.stderr.write(`Daemon: cannot connect to Chrome: ${e.message}\n`);
+    removeDaemonSession({ daemonId, socketPath, metadataPath });
     process.exit(1);
   }
 
@@ -448,22 +713,22 @@ async function runDaemon(targetId) {
     sessionId = res.sessionId;
   } catch (e) {
     process.stderr.write(`Daemon: attach failed: ${e.message}\n`);
+    removeDaemonSession({ daemonId, socketPath, metadataPath });
     cdp.close();
     process.exit(1);
   }
 
-  // Shutdown helpers
   let alive = true;
+  let server;
   function shutdown() {
     if (!alive) return;
     alive = false;
-    server.close();
-    try { unlinkSync(sp); } catch {}
+    removeDaemonSession({ daemonId, socketPath, metadataPath });
+    server?.close();
     cdp.close();
     process.exit(0);
   }
 
-  // Exit if target goes away or Chrome disconnects
   cdp.onEvent('Target.targetDestroyed', (params) => {
     if (params.targetId === targetId) shutdown();
   });
@@ -474,14 +739,13 @@ async function runDaemon(targetId) {
   process.on('SIGTERM', shutdown);
   process.on('SIGINT', shutdown);
 
-  // Idle timer
+  // Idle daemons auto-exit so abandoned tab sessions do not linger forever.
   let idleTimer = setTimeout(shutdown, IDLE_TIMEOUT);
   function resetIdle() {
     clearTimeout(idleTimer);
     idleTimer = setTimeout(shutdown, IDLE_TIMEOUT);
   }
 
-  // Handle a command
   async function handleCommand({ cmd, args }) {
     resetIdle();
     try {
@@ -497,19 +761,47 @@ async function runDaemon(targetId) {
           result = JSON.stringify(pages);
           break;
         }
-        case 'snap': case 'snapshot': result = await snapshotStr(cdp, sessionId, true); break;
-        case 'eval': result = await evalStr(cdp, sessionId, args[0]); break;
-        case 'shot': case 'screenshot': result = await shotStr(cdp, sessionId, args[0]); break;
-        case 'html': result = await htmlStr(cdp, sessionId, args[0]); break;
-        case 'nav': case 'navigate': result = await navStr(cdp, sessionId, args[0]); break;
-        case 'net': case 'network': result = await netStr(cdp, sessionId); break;
-        case 'click': result = await clickStr(cdp, sessionId, args[0]); break;
-        case 'clickxy': result = await clickXyStr(cdp, sessionId, args[0], args[1]); break;
-        case 'type': result = await typeStr(cdp, sessionId, args[0]); break;
-        case 'loadall': result = await loadAllStr(cdp, sessionId, args[0], args[1] ? parseInt(args[1]) : 1500); break;
-        case 'evalraw': result = await evalRawStr(cdp, sessionId, args[0], args[1]); break;
-        case 'stop': return { ok: true, result: '', stopAfter: true };
-        default: return { ok: false, error: `Unknown command: ${cmd}` };
+        case 'snap':
+        case 'snapshot':
+          result = await snapshotStr(cdp, sessionId, true);
+          break;
+        case 'eval':
+          result = await evalStr(cdp, sessionId, args[0]);
+          break;
+        case 'shot':
+        case 'screenshot':
+          result = await shotStr(cdp, sessionId, args[0]);
+          break;
+        case 'html':
+          result = await htmlStr(cdp, sessionId, args[0]);
+          break;
+        case 'nav':
+        case 'navigate':
+          result = await navStr(cdp, sessionId, args[0]);
+          break;
+        case 'net':
+        case 'network':
+          result = await netStr(cdp, sessionId);
+          break;
+        case 'click':
+          result = await clickStr(cdp, sessionId, args[0]);
+          break;
+        case 'clickxy':
+          result = await clickXyStr(cdp, sessionId, args[0], args[1]);
+          break;
+        case 'type':
+          result = await typeStr(cdp, sessionId, args[0]);
+          break;
+        case 'loadall':
+          result = await loadAllStr(cdp, sessionId, args[0], args[1] ? parseInt(args[1], 10) : 1500);
+          break;
+        case 'evalraw':
+          result = await evalRawStr(cdp, sessionId, args[0], args[1]);
+          break;
+        case 'stop':
+          return { ok: true, result: '', stopAfter: true };
+        default:
+          return { ok: false, error: `Unknown command: ${cmd}` };
       }
       return { ok: true, result: result ?? '' };
     } catch (e) {
@@ -517,17 +809,12 @@ async function runDaemon(targetId) {
     }
   }
 
-  // Unix socket server — NDJSON protocol
-  // Wire format: each message is one JSON object followed by \n (newline-delimited JSON).
-  // Request:  { "id": <number>, "cmd": "<command>", "args": ["arg1", "arg2", ...] }
-  // Response: { "id": <number>, "ok": <boolean>, "result": "<string>" }
-  //           or { "id": <number>, "ok": false, "error": "<message>" }
-  const server = net.createServer((conn) => {
+  server = net.createServer((conn) => {
     let buf = '';
     conn.on('data', (chunk) => {
       buf += chunk.toString();
       const lines = buf.split('\n');
-      buf = lines.pop(); // keep incomplete last line
+      buf = lines.pop();
       for (const line of lines) {
         if (!line.trim()) continue;
         let req;
@@ -535,6 +822,13 @@ async function runDaemon(targetId) {
           req = JSON.parse(line);
         } catch {
           conn.write(JSON.stringify({ ok: false, error: 'Invalid JSON request', id: null }) + '\n');
+          continue;
+        }
+        // Every daemon request must present the per-daemon token from that
+        // daemon's private metadata file.
+        if (req.token !== token) {
+          conn.write(JSON.stringify({ ok: false, error: 'Unauthorized daemon request', id: req.id ?? null }) + '\n');
+          conn.end();
           continue;
         }
         handleCommand(req).then((res) => {
@@ -546,47 +840,84 @@ async function runDaemon(targetId) {
     });
   });
 
-  try { unlinkSync(sp); } catch {}
-  server.listen(sp);
-}
-
-// ---------------------------------------------------------------------------
-// CLI ↔ daemon communication
-// ---------------------------------------------------------------------------
-
-function connectToSocket(sp) {
-  return new Promise((resolve, reject) => {
-    const conn = net.connect(sp);
-    conn.on('connect', () => resolve(conn));
-    conn.on('error', reject);
+  server.listen(socketPath, () => {
+    try {
+      chmodSync(socketPath, SOCKET_MODE);
+      writeDaemonMetadata({
+        daemonId,
+        targetId,
+        socketPath,
+        token,
+        createdAt: new Date().toISOString(),
+        metadataPath,
+      });
+    } catch (e) {
+      process.stderr.write(`Daemon: failed to secure socket: ${e.message}\n`);
+      shutdown();
+    }
   });
 }
 
+function connectToSocket(socketPath) {
+  if (testHooks.connectToSocket) return testHooks.connectToSocket(socketPath);
+  return new Promise((resolveConn, rejectConn) => {
+    const conn = net.connect(socketPath);
+    conn.on('connect', () => resolveConn(conn));
+    conn.on('error', rejectConn);
+  });
+}
+
+async function cleanupStaleDaemon(entry) {
+  return removeDaemonSession(entry);
+}
+
+// Reuse an existing daemon for the target when possible; otherwise spawn a new
+// detached helper and wait for its socket to come up. The order is:
+// 1. try reachable existing daemon metadata
+// 2. create metadata for a new daemon
+// 3. spawn the helper process
+// 4. poll until its socket is connectable
 async function getOrStartTabDaemon(targetId) {
-  const sp = sockPath(targetId);
-  // Try existing daemon
-  try { return await connectToSocket(sp); } catch {}
+  const existing = listDaemonSockets().find(daemon => daemon.targetId === targetId);
+  if (existing) {
+    try {
+      const conn = await connectToSocket(existing.socketPath);
+      return { conn, token: existing.token };
+    } catch {
+      await cleanupStaleDaemon(existing);
+    }
+  }
 
-  // Clean stale socket
-  try { unlinkSync(sp); } catch {}
-
-  // Spawn daemon
-  const child = spawn(process.execPath, [process.argv[1], '_daemon', targetId], {
+  const entry = createDaemonSession(targetId);
+  const spawnFn = testHooks.spawn || spawn;
+  const child = spawnFn(process.execPath, [
+    process.argv[1],
+    '_daemon',
+    targetId,
+    entry.daemonId,
+    entry.socketPath,
+    entry.token,
+    entry.metadataPath,
+  ], {
     detached: true,
     stdio: 'ignore',
   });
   child.unref();
 
-  // Wait for socket (includes time for user to click Allow)
   for (let i = 0; i < DAEMON_CONNECT_RETRIES; i++) {
     await sleep(DAEMON_CONNECT_DELAY);
-    try { return await connectToSocket(sp); } catch {}
+    try {
+      const conn = await connectToSocket(entry.socketPath);
+      return { conn, token: entry.token };
+    } catch {}
   }
+
+  await cleanupStaleDaemon(entry);
   throw new Error('Daemon failed to start — did you click Allow in Chrome?');
 }
 
-function sendCommand(conn, req) {
-  return new Promise((resolve, reject) => {
+function sendCommand(conn, req, token) {
+  return new Promise((resolveResponse, rejectResponse) => {
     let buf = '';
     let settled = false;
 
@@ -603,7 +934,7 @@ function sendCommand(conn, req) {
       if (idx === -1) return;
       settled = true;
       cleanup();
-      resolve(JSON.parse(buf.slice(0, idx)));
+      resolveResponse(JSON.parse(buf.slice(0, idx)));
       conn.end();
     };
 
@@ -611,41 +942,39 @@ function sendCommand(conn, req) {
       if (settled) return;
       settled = true;
       cleanup();
-      reject(error);
+      rejectResponse(error);
     };
 
     const onEnd = () => {
       if (settled) return;
       settled = true;
       cleanup();
-      reject(new Error('Connection closed before response'));
+      rejectResponse(new Error('Connection closed before response'));
     };
 
     const onClose = () => {
       if (settled) return;
       settled = true;
       cleanup();
-      reject(new Error('Connection closed before response'));
+      rejectResponse(new Error('Connection closed before response'));
     };
 
     conn.on('data', onData);
     conn.on('error', onError);
     conn.on('end', onEnd);
     conn.on('close', onClose);
+    // The daemon protocol is newline-delimited JSON; one request, one response.
     req.id = 1;
+    req.token = token;
     conn.write(JSON.stringify(req) + '\n');
   });
 }
 
-// Find any running daemon socket to reuse for list
 function findAnyDaemonSocket() {
-  return listDaemonSockets()[0]?.socketPath || null;
+  return listDaemonSockets()[0] || null;
 }
 
-// ---------------------------------------------------------------------------
-// Stop daemons
-// ---------------------------------------------------------------------------
-
+// Stop either one daemon matched by target prefix, or all running daemons.
 async function stopDaemons(targetPrefix) {
   const daemons = listDaemonSockets();
 
@@ -654,9 +983,9 @@ async function stopDaemons(targetPrefix) {
     const daemon = daemons.find(d => d.targetId === targetId);
     try {
       const conn = await connectToSocket(daemon.socketPath);
-      await sendCommand(conn, { cmd: 'stop' });
+      await sendCommand(conn, { cmd: 'stop' }, daemon.token);
     } catch {
-      try { unlinkSync(daemon.socketPath); } catch {}
+      await cleanupStaleDaemon(daemon);
     }
     return;
   }
@@ -664,25 +993,39 @@ async function stopDaemons(targetPrefix) {
   for (const daemon of daemons) {
     try {
       const conn = await connectToSocket(daemon.socketPath);
-      await sendCommand(conn, { cmd: 'stop' });
+      await sendCommand(conn, { cmd: 'stop' }, daemon.token);
     } catch {
-      try { unlinkSync(daemon.socketPath); } catch {}
+      await cleanupStaleDaemon(daemon);
     }
   }
 }
 
-// ---------------------------------------------------------------------------
-// Main
-// ---------------------------------------------------------------------------
+function isUnsafeAllowed(argv) {
+  if (process.env[ALLOW_UNSAFE_ENV] === '1') return true;
+  if (process.env[ALLOW_UNSAFE_ENV]?.toLowerCase?.() === 'true') return true;
+  return argv.includes('--allow-unsafe');
+}
+
+function stripGlobalFlags(argv) {
+  return argv.filter(arg => arg !== '--allow-unsafe');
+}
+
+function assertUnsafeAllowed(cmd, allowUnsafe) {
+  if (!['eval', 'evalraw'].includes(cmd) || allowUnsafe) return;
+  throw new Error(
+    `Command "${cmd}" is disabled by default because it can execute arbitrary page/CDP code. ` +
+    `Re-run with --allow-unsafe or set ${ALLOW_UNSAFE_ENV}=1 if you explicitly trust this session.`
+  );
+}
 
 const USAGE = `cdp - lightweight Chrome DevTools Protocol CLI (no Puppeteer)
 
-Usage: cdp <command> [args]
+Usage: cdp [--allow-unsafe] <command> [args]
 
   list                              List open pages (shows unique target prefixes)
   snap  <target>                    Accessibility tree snapshot
-  eval  <target> <expr>             Evaluate JS expression
-  shot  <target> [file]             Screenshot (default: /tmp/screenshot.png); prints coordinate mapping
+  eval  <target> <expr>             Evaluate JS expression (requires --allow-unsafe)
+  shot  <target> [file]             Screenshot (default: private runtime path); prints coordinate mapping
   html  <target> [selector]         Get HTML (full page or CSS selector)
   nav   <target> <url>              Navigate to URL and wait for load completion
   net   <target>                    Network performance entries
@@ -692,12 +1035,28 @@ Usage: cdp <command> [args]
                                     Works in cross-origin iframes unlike eval-based approaches
   loadall <target> <selector> [ms]  Repeatedly click a "load more" button until it disappears
                                     Optional interval in ms between clicks (default 1500)
-  evalraw <target> <method> [json]  Send a raw CDP command; returns JSON result
-                                    e.g. evalraw <t> "DOM.getDocument" '{}'
+  evalraw <target> <method> [json]  Send a raw CDP command; requires --allow-unsafe
   stop  [target]                    Stop daemon(s)
 
 <target> is a unique targetId prefix from "cdp list". If a prefix is ambiguous,
 use more characters.
+
+UNSAFE COMMANDS
+  eval and evalraw are disabled by default because they can execute arbitrary
+  JavaScript or raw CDP methods against the attached tab.
+  To enable them for a trusted session:
+    Run the command with the flag:
+      cdp --allow-unsafe eval <target> "document.title"
+    Or set the env var for that command:
+      ${ALLOW_UNSAFE_ENV}=1 cdp eval <target> "document.title"
+    If you use this through a skill/agent, update the command it runs so it
+    includes --allow-unsafe for eval/evalraw commands.
+
+RUNTIME SECURITY
+  Runtime files live under a private per-user directory:
+    ${RUNTIME_ROOT}
+  Cache and daemon metadata files are owner-only (0600). Daemon sockets are randomized,
+  stored in that directory, and authenticated with a per-daemon session token.
 
 COORDINATE SYSTEM
   shot captures the viewport at the device's native resolution.
@@ -717,67 +1076,80 @@ EVAL SAFETY NOTE
   collect all data in a single eval.
 
 DAEMON IPC (for advanced use / scripting)
-  Each tab runs a persistent daemon at Unix socket: /tmp/cdp-<fullTargetId>.sock
+  Each tab runs a persistent daemon at a randomized Unix socket path inside the
+  private runtime directory above. Daemon metadata lives under that runtime root.
   Protocol: newline-delimited JSON (one JSON object per line, UTF-8).
-    Request:  {"id":<number>, "cmd":"<command>", "args":["arg1","arg2",...]}
+    Request:  {"id":<number>, "token":"<session-token>", "cmd":"<command>", "args":["arg1","arg2",...]}
     Response: {"id":<number>, "ok":true,  "result":"<string>"}
            or {"id":<number>, "ok":false, "error":"<message>"}
   Commands mirror the CLI: snap, eval, shot, html, nav, net, click, clickxy,
-  type, loadall, evalraw, stop. Use evalraw to send arbitrary CDP methods.
+  type, loadall, evalraw, stop. Use evalraw only in explicitly trusted flows.
   The socket disappears after 20 min of inactivity or when the tab closes.
 `;
 
 const NEEDS_TARGET = new Set([
-  'snap','snapshot','eval','shot','screenshot','html','nav','navigate',
-  'net','network','click','clickxy','type','loadall','evalraw',
+  'snap', 'snapshot', 'eval', 'shot', 'screenshot', 'html', 'nav', 'navigate',
+  'net', 'network', 'click', 'clickxy', 'type', 'loadall', 'evalraw',
 ]);
 
 async function main() {
-  const [cmd, ...args] = process.argv.slice(2);
+  ensureRuntimeRoot();
 
-  // Daemon mode (internal)
-  if (cmd === '_daemon') { await runDaemon(args[0]); return; }
+  const rawArgv = process.argv.slice(2);
+  const allowUnsafe = isUnsafeAllowed(rawArgv);
+  const argv = stripGlobalFlags(rawArgv);
+  const [cmd, ...args] = argv;
 
-  if (!cmd || cmd === 'help' || cmd === '--help' || cmd === '-h') {
-    console.log(USAGE); process.exit(0);
+  if (cmd === '_daemon') {
+    // Internal mode used only by the parent CLI when it spawns a background
+    // per-tab daemon.
+    await runDaemon(args[0], args[1], args[2], args[3], args[4]);
+    return;
   }
 
-  // List — use existing daemon if available, otherwise direct
+  if (!cmd || cmd === 'help' || cmd === '--help' || cmd === '-h') {
+    console.log(USAGE);
+    process.exit(0);
+  }
+
   if (cmd === 'list' || cmd === 'ls') {
     let pages;
-    const existingSock = findAnyDaemonSocket();
-    if (existingSock) {
+    const existingDaemon = findAnyDaemonSocket();
+    if (existingDaemon) {
       try {
-        const conn = await connectToSocket(existingSock);
-        const resp = await sendCommand(conn, { cmd: 'list_raw' });
+        // Listing through an existing daemon avoids an extra Chrome attach and
+        // therefore avoids another "Allow debugging" prompt.
+        const conn = await connectToSocket(existingDaemon.socketPath);
+        const resp = await sendCommand(conn, { cmd: 'list_raw' }, existingDaemon.token);
         if (resp.ok) pages = JSON.parse(resp.result);
-      } catch {}
+      } catch {
+        await cleanupStaleDaemon(existingDaemon);
+      }
     }
     if (!pages) {
-      // No daemon running — connect directly (will trigger one Allow)
       const cdp = new CDP();
       await cdp.connect(getWsUrl());
       pages = await getPages(cdp);
       cdp.close();
     }
-    writeFileSync(PAGES_CACHE, JSON.stringify(pages));
+    writePrivateJson(PAGES_CACHE, pages);
     console.log(formatPageList(pages));
     setTimeout(() => process.exit(0), 100);
     return;
   }
 
-  // Stop
   if (cmd === 'stop') {
     await stopDaemons(args[0]);
     return;
   }
 
-  // Page commands — need target prefix
   if (!NEEDS_TARGET.has(cmd)) {
     console.error(`Unknown command: ${cmd}\n`);
     console.log(USAGE);
     process.exit(1);
   }
+
+  assertUnsafeAllowed(cmd, allowUnsafe);
 
   const targetPrefix = args[0];
   if (!targetPrefix) {
@@ -785,38 +1157,46 @@ async function main() {
     process.exit(1);
   }
 
-  // Resolve prefix → full targetId from cache or running daemon
   let targetId;
-  const daemonTargetIds = listDaemonSockets().map(d => d.targetId);
+  const daemons = listDaemonSockets();
+  const daemonTargetIds = daemons.map(d => d.targetId);
   const daemonMatches = daemonTargetIds.filter(id => id.toUpperCase().startsWith(targetPrefix.toUpperCase()));
 
   if (daemonMatches.length > 0) {
+    // Prefer a running daemon when one already exists for the target prefix.
     targetId = resolvePrefix(targetPrefix, daemonTargetIds, 'daemon');
   } else {
     if (!existsSync(PAGES_CACHE)) {
       console.error('No page list cached. Run "cdp list" first.');
       process.exit(1);
     }
+    ensurePrivateFile(PAGES_CACHE);
     const pages = JSON.parse(readFileSync(PAGES_CACHE, 'utf8'));
     targetId = resolvePrefix(targetPrefix, pages.map(p => p.targetId), 'target', 'Run "cdp list".');
   }
 
-  const conn = await getOrStartTabDaemon(targetId);
-
+  const { conn, token } = await getOrStartTabDaemon(targetId);
   const cmdArgs = args.slice(1);
 
   if (cmd === 'eval') {
     const expr = cmdArgs.join(' ');
-    if (!expr) { console.error('Error: expression required'); process.exit(1); }
+    if (!expr) {
+      console.error('Error: expression required');
+      process.exit(1);
+    }
     cmdArgs[0] = expr;
   } else if (cmd === 'type') {
-    // Join all remaining args as text (allows spaces)
     const text = cmdArgs.join(' ');
-    if (!text) { console.error('Error: text required'); process.exit(1); }
+    if (!text) {
+      console.error('Error: text required');
+      process.exit(1);
+    }
     cmdArgs[0] = text;
   } else if (cmd === 'evalraw') {
-    // args: [method, ...jsonParts] — join json parts in case of spaces
-    if (!cmdArgs[0]) { console.error('Error: CDP method required'); process.exit(1); }
+    if (!cmdArgs[0]) {
+      console.error('Error: CDP method required');
+      process.exit(1);
+    }
     if (cmdArgs.length > 2) cmdArgs[1] = cmdArgs.slice(1).join(' ');
   }
 
@@ -825,7 +1205,7 @@ async function main() {
     process.exit(1);
   }
 
-  const response = await sendCommand(conn, { cmd, args: cmdArgs });
+  const response = await sendCommand(conn, { cmd, args: cmdArgs }, token);
 
   if (response.ok) {
     if (response.result) console.log(response.result);
@@ -835,4 +1215,52 @@ async function main() {
   }
 }
 
-main().catch(e => { console.error(e.message); process.exit(1); });
+// Narrow internal export surface used by the test suite. This is not intended
+// to be treated as a stable API outside tests and local maintenance work.
+const testInternals = {
+  ALLOW_UNSAFE_ENV,
+  DAEMONS_DIR,
+  DIR_MODE,
+  FILE_MODE,
+  PAGES_CACHE,
+  RUNTIME_ROOT,
+  SOCKET_MODE,
+  assertUnsafeAllowed,
+  cleanupInvalidDaemonMetadata,
+  cleanupStaleDaemonEntries,
+  createDaemonSession,
+  daemonMetadataPath,
+  defaultScreenshotPath,
+  discoverDaemonEntries,
+  ensurePrivateDir,
+  ensurePrivateFile,
+  findAnyDaemonSocket,
+  initRuntimeRoot,
+  isSocketFile,
+  isUnsafeAllowed,
+  isWithinDir,
+  listDaemonMetadataFiles,
+  listDaemonSockets,
+  readDaemonMetadata,
+  removeDaemonSession,
+  runtimeRootCandidates,
+  safeRemoveDaemonMetadata,
+  safeRemoveRuntimeSocket,
+  sendCommand,
+  stopDaemons,
+  stripGlobalFlags,
+  writeDaemonMetadata,
+  writePrivateFile,
+  writePrivateJson,
+  getOrStartTabDaemon,
+  testHooks,
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(e => {
+    console.error(e.message);
+    process.exit(1);
+  });
+}
+
+export { testInternals };

--- a/skills/chrome-cdp/scripts/cdp.test.mjs
+++ b/skills/chrome-cdp/scripts/cdp.test.mjs
@@ -1,0 +1,266 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync, statSync, writeFileSync } from 'fs';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+
+const testRuntimeBase = mkdtempSync('/tmp/chrome-cdp-test-');
+process.env.XDG_RUNTIME_DIR = testRuntimeBase;
+
+const { testInternals: cdp } = await import('./cdp.mjs');
+
+test.after(() => {
+  rmSync(testRuntimeBase, { recursive: true, force: true });
+});
+
+function createFakeDaemon(entry, { requireToken = true } = {}) {
+  const requests = [];
+  let closed = false;
+
+  class FakeConnection {
+    constructor() {
+      this.handlers = new Map();
+    }
+
+    on(event, handler) {
+      if (!this.handlers.has(event)) this.handlers.set(event, new Set());
+      this.handlers.get(event).add(handler);
+    }
+
+    off(event, handler) {
+      this.handlers.get(event)?.delete(handler);
+    }
+
+    emit(event, payload) {
+      for (const handler of this.handlers.get(event) || []) {
+        handler(payload);
+      }
+    }
+
+    write(line) {
+      const req = JSON.parse(line.trim());
+      requests.push(req);
+      const response = requireToken && req.token !== entry.token
+        ? { ok: false, error: 'Unauthorized daemon request', id: req.id ?? null }
+        : { ok: true, result: req.cmd === 'stop' ? '' : 'ok', id: req.id };
+      this.emit('data', Buffer.from(`${JSON.stringify(response)}\n`));
+      this.emit('end');
+      this.emit('close');
+      if (req.cmd === 'stop') closed = true;
+    }
+
+    end() {}
+  }
+
+  return {
+    closed: () => closed,
+    connect: async () => new FakeConnection(),
+    requests,
+  };
+}
+
+test('runtime root is created with owner-only permissions', () => {
+  cdp.listDaemonMetadataFiles();
+  assert.equal(existsSync(cdp.RUNTIME_ROOT), true);
+  assert.equal(statSync(cdp.RUNTIME_ROOT).mode & 0o777, cdp.DIR_MODE);
+  assert.match(cdp.RUNTIME_ROOT, new RegExp(`^${testRuntimeBase}`));
+  assert.equal(statSync(cdp.DAEMONS_DIR).mode & 0o777, cdp.DIR_MODE);
+});
+
+test('writePrivateJson writes owner-only files', () => {
+  const filePath = join(cdp.RUNTIME_ROOT, 'private.json');
+  cdp.writePrivateJson(filePath, { ok: true });
+
+  assert.deepEqual(JSON.parse(readFileSync(filePath, 'utf8')), { ok: true });
+  assert.equal(statSync(filePath).mode & 0o777, cdp.FILE_MODE);
+});
+
+test('createDaemonSession writes one owner-only metadata file with randomized socket metadata', () => {
+  const before = cdp.listDaemonMetadataFiles();
+  const entry = cdp.createDaemonSession('target-session-test');
+  const after = cdp.listDaemonMetadataFiles();
+
+  assert.equal(after.length, before.length + 1);
+  assert.equal(typeof entry.daemonId, 'string');
+  assert.equal(typeof entry.token, 'string');
+  assert.equal(entry.token.length, 48);
+  assert.match(entry.socketPath, /^.*daemon-[a-f0-9]+\.sock$/);
+  assert.match(entry.metadataPath, /^.*daemons\/[a-f0-9]+\.json$/);
+  assert.equal(statSync(entry.metadataPath).mode & 0o777, cdp.FILE_MODE);
+  assert.deepEqual(cdp.readDaemonMetadata(entry.metadataPath), entry);
+});
+
+test('discoverDaemonEntries classifies valid, invalid, and stale entries without mutating', () => {
+  const valid = cdp.createDaemonSession('valid-target');
+  const stale = cdp.createDaemonSession('stale-target');
+  const invalidMetadataPath = join(cdp.DAEMONS_DIR, 'invalid.json');
+
+  writeFileSync(valid.socketPath, '', { mode: cdp.FILE_MODE });
+  cdp.writePrivateJson(invalidMetadataPath, { nope: true });
+  cdp.testHooks.isSocketFile = (filePath) => filePath === valid.socketPath;
+
+  const discovered = cdp.discoverDaemonEntries();
+
+  assert.equal(discovered.valid.some(d => d.daemonId === valid.daemonId), true);
+  assert.equal(discovered.stale.some(d => d.entry.daemonId === stale.daemonId), true);
+  assert.equal(discovered.invalidMetadata.some(d => d.metadataPath === invalidMetadataPath), true);
+  assert.equal(existsSync(stale.metadataPath), true);
+  assert.equal(existsSync(invalidMetadataPath), true);
+  cdp.testHooks.isSocketFile = null;
+});
+
+test('cleanup helpers remove invalid metadata and stale daemon metadata while preserving non-socket files', () => {
+  const stale = cdp.createDaemonSession('stale-cleanup-target');
+  const invalidMetadataPath = join(cdp.DAEMONS_DIR, 'invalid-cleanup.json');
+  const fakeFileAtSocketPath = join(cdp.RUNTIME_ROOT, 'daemon-not-a-socket.sock');
+  const poisonedEntry = {
+    daemonId: 'poisoned-file',
+    targetId: 'poisoned-target',
+    socketPath: fakeFileAtSocketPath,
+    token: 'z'.repeat(48),
+    createdAt: '2026-03-14T00:00:02.000Z',
+    metadataPath: join(cdp.DAEMONS_DIR, 'poisoned-file.json'),
+  };
+
+  cdp.writePrivateJson(invalidMetadataPath, { nope: true });
+  writeFileSync(fakeFileAtSocketPath, 'keep-me', { mode: cdp.FILE_MODE });
+  cdp.writeDaemonMetadata(poisonedEntry);
+
+  const discovered = cdp.discoverDaemonEntries();
+  const invalidResults = cdp.cleanupInvalidDaemonMetadata(discovered.invalidMetadata);
+  const staleResults = cdp.cleanupStaleDaemonEntries(discovered.stale);
+
+  assert.equal(invalidResults.some(r => r.metadataPath === invalidMetadataPath && r.metadataResult.removed), true);
+  assert.equal(staleResults.some(r => r.daemonId === stale.daemonId && r.metadataResult.removed), true);
+  assert.equal(staleResults.some(r => r.daemonId === 'poisoned-file' && r.socketResult.reason === 'not_socket'), true);
+  assert.equal(existsSync(fakeFileAtSocketPath), true);
+  assert.equal(readFileSync(fakeFileAtSocketPath, 'utf8'), 'keep-me');
+});
+
+test('listDaemonSockets returns multiple daemon entries from independent metadata files', async () => {
+  const first = cdp.createDaemonSession('target-a');
+  const second = cdp.createDaemonSession('target-b');
+  cdp.testHooks.isSocketFile = (filePath) => filePath === first.socketPath || filePath === second.socketPath;
+  writeFileSync(first.socketPath, '', { mode: cdp.FILE_MODE });
+  writeFileSync(second.socketPath, '', { mode: cdp.FILE_MODE });
+
+  const daemons = cdp.listDaemonSockets().filter(d => d.daemonId === first.daemonId || d.daemonId === second.daemonId);
+
+  assert.deepEqual(daemons.map(d => d.targetId).sort(), ['target-a', 'target-b']);
+  cdp.testHooks.isSocketFile = null;
+});
+
+test('poisoned metadata outside runtime root is dropped without deleting external file', () => {
+  const externalFile = join(testRuntimeBase, 'outside.txt');
+  const poisonedMetadataPath = join(cdp.DAEMONS_DIR, 'poisoned.json');
+  writeFileSync(externalFile, 'keep-me', { mode: cdp.FILE_MODE });
+  cdp.writePrivateJson(poisonedMetadataPath, {
+    daemonId: 'poisoned',
+    targetId: 'poisoned-target',
+    socketPath: externalFile,
+    token: 'c'.repeat(48),
+    createdAt: '2026-03-14T00:00:02.000Z',
+  });
+
+  const daemons = cdp.listDaemonSockets();
+
+  assert.equal(daemons.some(d => d.daemonId === 'poisoned'), false);
+  assert.equal(existsSync(poisonedMetadataPath), false);
+  assert.equal(existsSync(externalFile), true);
+  assert.equal(readFileSync(externalFile, 'utf8'), 'keep-me');
+});
+
+test('removeDaemonSession reports metadata removal and preserves non-socket files at socket paths', () => {
+  const entry = cdp.createDaemonSession('cleanup-target');
+  writeFileSync(entry.socketPath, '', { mode: cdp.FILE_MODE });
+  const result = cdp.removeDaemonSession(entry);
+
+  assert.equal(existsSync(entry.metadataPath), false);
+  assert.equal(existsSync(entry.socketPath), true);
+  assert.equal(result.socketResult.reason, 'not_socket');
+  assert.equal(result.metadataResult.removed, true);
+});
+
+test('sendCommand injects the daemon token and parses one NDJSON response', async () => {
+  const entry = cdp.createDaemonSession('send-command-target');
+  const fake = createFakeDaemon(entry);
+  const conn = await fake.connect();
+
+  const response = await cdp.sendCommand(conn, { cmd: 'list_raw' }, entry.token);
+
+  assert.equal(response.ok, true);
+  assert.equal(fake.requests[0].token, entry.token);
+  assert.equal(fake.requests[0].cmd, 'list_raw');
+});
+
+test('getOrStartTabDaemon reuses an existing reachable daemon entry', async () => {
+  const entry = cdp.createDaemonSession('reuse-target');
+  const fake = createFakeDaemon(entry);
+  cdp.testHooks.isSocketFile = (filePath) => filePath === entry.socketPath;
+  cdp.testHooks.connectToSocket = async (socketPath) => {
+    assert.equal(socketPath, entry.socketPath);
+    return fake.connect();
+  };
+  writeFileSync(entry.socketPath, '', { mode: cdp.FILE_MODE });
+
+  const { conn, token } = await cdp.getOrStartTabDaemon('reuse-target');
+  const response = await cdp.sendCommand(conn, { cmd: 'list_raw' }, token);
+
+  assert.equal(token, entry.token);
+  assert.equal(response.ok, true);
+  assert.equal(fake.requests[0].cmd, 'list_raw');
+  cdp.testHooks.connectToSocket = null;
+  cdp.testHooks.isSocketFile = null;
+});
+
+test('stopDaemons can discover and stop a fake daemon via metadata', async () => {
+  const entry = cdp.createDaemonSession('stop-target');
+  const fake = createFakeDaemon(entry);
+  cdp.testHooks.isSocketFile = (filePath) => filePath === entry.socketPath;
+  cdp.testHooks.connectToSocket = async (socketPath) => {
+    assert.equal(socketPath, entry.socketPath);
+    return fake.connect();
+  };
+  writeFileSync(entry.socketPath, '', { mode: cdp.FILE_MODE });
+
+  await cdp.stopDaemons('stop-target');
+
+  assert.equal(fake.requests.some(req => req.cmd === 'stop'), true);
+  assert.equal(fake.closed(), true);
+  cdp.testHooks.connectToSocket = null;
+  cdp.testHooks.isSocketFile = null;
+});
+
+test('fake daemon rejects unauthorized requests in harnessed flow', async () => {
+  const entry = cdp.createDaemonSession('auth-target');
+  const fake = createFakeDaemon(entry);
+  const conn = await fake.connect();
+
+  const response = await cdp.sendCommand(conn, { cmd: 'list_raw' }, 'wrong-token');
+
+  assert.equal(response.ok, false);
+  assert.match(response.error, /Unauthorized/);
+});
+
+test('unsafe gating rejects eval and evalraw unless explicitly allowed', () => {
+  assert.throws(() => cdp.assertUnsafeAllowed('eval', false), /disabled by default/);
+  assert.throws(() => cdp.assertUnsafeAllowed('evalraw', false), /disabled by default/);
+  assert.doesNotThrow(() => cdp.assertUnsafeAllowed('snap', false));
+  assert.doesNotThrow(() => cdp.assertUnsafeAllowed('eval', true));
+});
+
+test('unsafe flag helpers recognize CLI flag and env var', () => {
+  delete process.env[cdp.ALLOW_UNSAFE_ENV];
+  assert.equal(cdp.isUnsafeAllowed(['list']), false);
+  assert.equal(cdp.isUnsafeAllowed(['--allow-unsafe', 'eval']), true);
+  process.env[cdp.ALLOW_UNSAFE_ENV] = 'true';
+  assert.equal(cdp.isUnsafeAllowed(['list']), true);
+  delete process.env[cdp.ALLOW_UNSAFE_ENV];
+  assert.deepEqual(cdp.stripGlobalFlags(['--allow-unsafe', 'eval', 'abc']), ['eval', 'abc']);
+});
+
+test('default screenshot path stays inside the private runtime root', () => {
+  const screenshotPath = cdp.defaultScreenshotPath();
+  assert.match(screenshotPath, new RegExp(`^${cdp.RUNTIME_ROOT}`));
+  assert.match(screenshotPath, /screenshot-.*\.png$/);
+});


### PR DESCRIPTION
## Summary

This PR tightens up the local security model for `chrome-cdp` and cleans up the docs so they are written for people actually using this as a skill, not as a standalone CLI.

On the security side, the biggest changes are:
- moving runtime artifacts out of shared `/tmp`
- using randomized per-daemon sockets instead of predictable socket paths
- adding a simple per-daemon token for local IPC
- requiring explicit opt-in for `eval` / `evalraw`
- replacing the shared daemon index with per-daemon metadata files

On the usability side, the README has been rewritten to feel much more natural for Codex / Claude / skill users, and the `cdp.mjs` internals are now better structured and easier to follow.

## What changed

### Safer local runtime
The script now uses a private runtime directory with owner-only permissions instead of relying on global `/tmp` paths. That includes daemon metadata, cached page data, and default screenshot output.

Per-daemon sockets are now randomized and stored under that private runtime, which makes them much less discoverable. Each daemon also gets its own token, and daemon requests are rejected if the token is missing or wrong.

### Better daemon bookkeeping
The old shared index file was replaced with per-daemon metadata files. That fixes two problems at once:
- no more shared read/modify/write index updates that can clobber each other
- no more risky cleanup path where poisoned metadata could cause the script to unlink the wrong file

The daemon discovery flow was also split from cleanup so the logic is easier to reason about and test.

### Unsafe commands are now explicit
`eval` and `evalraw` are still available, but they are no longer on by default. You now have to opt into them with `--allow-unsafe` or `CDP_ALLOW_UNSAFE=1`.

That keeps the most powerful operations available when you really want them, while making normal skill usage safer by default.

### Tests
This PR adds a proper `node:test` suite around the daemon/runtime logic.

It covers things like:
- runtime permissions
- daemon metadata creation and discovery
- stale daemon cleanup
- poisoned metadata regression cases
- token handling and unauthorized requests
- daemon reuse / stop flows
- unsafe command gating

### Documentation
The README has been reworked quite a bit.

The main goal was to stop writing it like a terminal tool README and instead write it for someone using this through a skill in Codex, Claude Code, or a similar agent setup.

CLI/manual-debugging details are still there, but they are no longer the main story.

## Why

The old implementation worked, but it leaned heavily on local same-user trust assumptions:
- predictable socket paths in `/tmp`
- global temp files
- no app-level auth on the daemon protocol
- shared daemon bookkeeping that was a bit brittle

This PR doesn’t try to turn `chrome-cdp` into a sandbox. That’s not really what this tool is. But it does make the default setup a lot more defensive and a lot less fragile in shared or noisy local environments.

## Behavior changes

A couple of things are worth calling out:

- `eval` and `evalraw` now require explicit unsafe opt-in
- screenshot output no longer defaults to a fixed global `/tmp` path
- daemon discovery now comes from private runtime metadata instead of scanning global socket paths

Normal flows like listing tabs, taking snapshots, extracting HTML, navigating, clicking, and typing are unchanged from a user point of view.

## Verification

I verified this with:
- `npm test`
- `node --check`
- manual testing against a real Chrome session for:
  - `list`
  - `snap`
  - unauthorized daemon request rejection
  - `stop`
  - metadata/socket cleanup

## Final note

This makes the skill safer by default, but it is still a local-user tool with access to the Chrome session the user has chosen to expose. The goal here was practical hardening, not full isolation.