### PR TITLE
Add Chromium DevToolsActivePort path for Linux

### DIFF
--- a/skills/chrome-cdp/scripts/cdp.mjs
+++ b/skills/chrome-cdp/scripts/cdp.mjs
@@ -28,6 +28,7 @@ function getWsUrl() {
   const candidates = [
     resolve(homedir(), 'Library/Application Support/Google/Chrome/DevToolsActivePort'),
     resolve(homedir(), '.config/google-chrome/DevToolsActivePort'),
+    resolve(homedir(), '.config/chromium/DevToolsActivePort'),
   ];
   const portFile = candidates.find(path => existsSync(path));
   if (!portFile) throw new Error(`Could not find DevToolsActivePort file in: ${candidates.join(', ')}`);


### PR DESCRIPTION
## Summary
- Adds `~/.config/chromium/DevToolsActivePort` to the candidate paths
- Chromium on Linux uses a different config directory than Google Chrome (`~/.config/chromium/` vs `~/.config/google-chrome/`)
- Without this, the skill fails on Chromium with "Could not find DevToolsActivePort file"

## Test plan
- Tested on Arch Linux with Chromium — `list` command successfully returns open tabs