### PR TITLE
feat: add Linux Flatpak browser paths to DevToolsActivePort discovery

### DIFF
--- a/skills/chrome-cdp/scripts/cdp.mjs
+++ b/skills/chrome-cdp/scripts/cdp.mjs
@@ -48,6 +48,14 @@ function getWsUrl() {
     'vivaldi', 'vivaldi-snapshot',
     'BraveSoftware/Brave-Browser', 'microsoft-edge',
   ];
+  // Linux Flatpak: ~/.var/app/<app-id>/config/<name>/DevToolsActivePort
+  const flatpakBrowsers = [
+    ['org.chromium.Chromium', 'chromium'],
+    ['com.google.Chrome', 'google-chrome'],
+    ['com.brave.Browser', 'BraveSoftware/Brave-Browser'],
+    ['com.microsoft.Edge', 'microsoft-edge'],
+    ['com.vivaldi.Vivaldi', 'vivaldi'],
+  ];
   const candidates = [
     process.env.CDP_PORT_FILE,
     ...macBrowsers.flatMap(b => [
@@ -57,6 +65,10 @@ function getWsUrl() {
     ...linuxBrowsers.flatMap(b => [
       resolve(home, '.config', b, 'DevToolsActivePort'),
       resolve(home, '.config', b, 'Default/DevToolsActivePort'),
+    ]),
+    ...flatpakBrowsers.flatMap(([appId, name]) => [
+      resolve(home, '.var/app', appId, 'config', name, 'DevToolsActivePort'),
+      resolve(home, '.var/app', appId, 'config', name, 'Default/DevToolsActivePort'),
     ]),
     // Windows: %LOCALAPPDATA%/<name>/User Data/DevToolsActivePort
     ...(IS_WINDOWS ? ['Google/Chrome', 'BraveSoftware/Brave-Browser', 'Microsoft/Edge'].flatMap(b => {


### PR DESCRIPTION
## Summary

- Add Flatpak-sandboxed browser paths (`~/.var/app/<app-id>/config/`) as candidates in `getWsUrl()` for Chromium, Chrome, Brave, Edge, and Vivaldi
- Fixes failure on Flatpak-based Linux distros (e.g. Fedora Silverblue/Bluefin) where `DevToolsActivePort` is written under the Flatpak sandbox path instead of `~/.config/`
- No `CDP_PORT_FILE` workaround required after this fix

## Test plan

- [ ] Run `node cdp.mjs pages` on a system with Flatpak-installed Chromium running with `--remote-debugging-port`
- [ ] Verify the port file is discovered automatically without setting `CDP_PORT_FILE`
- [ ] Confirm existing non-Flatpak Linux paths still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)