### PR TITLE
fix: add list output presentation rules to prevent tab grouping and miscounting

### DIFF
--- a/skills/chrome-cdp/SKILL.md
+++ b/skills/chrome-cdp/SKILL.md
@@ -75,3 +75,9 @@ CSS px = screenshot image px / DPR
 - Prefer `snap --compact` over `html` for page structure.
 - Use `type` (not eval) to enter text in cross-origin iframes — `click`/`clickxy` to focus first, then `type`.
 - Chrome shows an "Allow debugging" modal once per tab on first access. A background daemon keeps the session alive so subsequent commands need no further approval. Daemons auto-exit after 20 minutes of inactivity.
+
+## Presenting `list` output
+
+- **One source line = one table row.** Never group tabs with similar titles into a single row.
+- Always count source lines first and state the total before presenting the table (e.g. "13 tabs open").
+- Verify: row count in your table must equal the line count from the raw output.


### PR DESCRIPTION
## Problem

When an AI agent runs `cdp.mjs list` and presents the output to a user, it may group tabs with similar titles into a single table row (e.g. three Intercom tabs collapsed into one row with IDs separated by `/`). This causes the reported tab count to be wrong — the agent says "12 tabs" when there are actually 13.

This is a systematic failure mode: the agent's table-building heuristic (deduplicate similar items) silently conflicts with the accuracy requirement (one tab = one row).

## Fix

Added a **"Presenting `list` output"** section to `SKILL.md` with three explicit rules:

- One source line = one table row (no grouping by title)
- Always count source lines first and state the total before presenting
- Verify: row count in the table must equal line count from raw output

## Why this belongs in the skill

This is skill-level behaviour — the instruction tells the AI agent how to handle this command's output. It does not belong in a global agent config or user memory.

## Discovered

Found while using the skill in a real session with 13 tabs open across multiple Intercom conversations.