### PR TITLE
feat: add Helium browser to macOS DevToolsActivePort discovery

### DIFF
--- a/skills/chrome-cdp/scripts/cdp.mjs
+++ b/skills/chrome-cdp/scripts/cdp.mjs
@@ -41,6 +41,7 @@ function getWsUrl() {
   const macBrowsers = [
     'Google/Chrome', 'Google/Chrome Beta', 'Google/Chrome for Testing',
     'Chromium', 'BraveSoftware/Brave-Browser', 'Microsoft Edge',
+    'net.imput.helium',
   ];
   // Linux: ~/.config/<name>/DevToolsActivePort
   const linuxBrowsers = [


### PR DESCRIPTION
## Summary

Adds [Helium](https://helium.computer) (`net.imput.helium`) to the macOS browser candidates in `getWsUrl()` so default discovery picks up its `DevToolsActivePort` without requiring `CDP_PORT_FILE`.

```diff
   const macBrowsers = [
     'Google/Chrome', 'Google/Chrome Beta', 'Google/Chrome for Testing',
     'Chromium', 'BraveSoftware/Brave-Browser', 'Microsoft Edge',
+    'net.imput.helium',
   ];
```

Helium is a privacy-focused Chromium fork for macOS. It uses its bundle id as the profile directory name (under `~/Library/Application Support/`), which is why it falls outside the existing entries.

## Tested

- Helium 0.11.7.1 (Chromium 147.0.7727.137 base) on macOS 15.4
- `cdp list`, `cdp shot`, `cdp nav` all working end-to-end

Note: Helium also requires `--remote-allow-origins=*` at launch (Chromium 128+ origin allowlist) for any `cdp.mjs` command to actually succeed — that's documented separately in #40 and is browser-side configuration, unrelated to this change.

## Test plan

- [x] `cdp list` discovers Helium's `DevToolsActivePort` automatically (no `CDP_PORT_FILE` env var).
- [x] Other browsers (Chrome, Brave, etc.) unaffected.