### PR TITLE
feat: add single daemon observability and inspect

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The CLI auto-detects Chrome, Chromium, Brave, Edge, and Vivaldi on macOS and Lin
 
 ```bash
 scripts/cdp.mjs list                              # list open tabs
+scripts/cdp.mjs stats                             # browser daemon health and recent command timings
+scripts/cdp.mjs inspect <target> [".selector"]    # lightweight page summary
 scripts/cdp.mjs shot   <target>                   # screenshot → runtime dir
 scripts/cdp.mjs snap   <target>                   # accessibility tree (compact, semantic)
 scripts/cdp.mjs html   <target> [".selector"]     # full HTML or scoped to CSS selector
@@ -60,3 +62,5 @@ scripts/cdp.mjs stop                             # stop the browser daemon
 Connects directly to Chrome's remote debugging WebSocket — no Puppeteer, no intermediary. A lightweight browser daemon keeps one CDP connection alive and manages tab sessions behind the scenes. Chrome's "Allow debugging" modal appears once per Chrome session; subsequent commands reuse the daemon silently. The daemon lives until Chrome disconnects or you run `scripts/cdp.mjs stop`.
 
 This approach is also why it handles 100+ open tabs reliably, where tools built on Puppeteer often time out during target enumeration.
+
+For agent workflows, start with `inspect` for page state. Escalate to `snap` when you need the full accessibility tree, `html` when you need raw markup, and `shot` when visual layout matters. Use `stats` when diagnosing slow local automation or checking whether the browser daemon is accumulating slow commands.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Clone or copy the `skills/chrome-cdp/` directory wherever your agent loads skill
 
 Navigate to `chrome://inspect/#remote-debugging` and toggle the switch. That's it.
 
-The CLI auto-detects Chrome, Chromium, Brave, Edge, and Vivaldi on macOS, Linux, and Windows. If your browser stores `DevToolsActivePort` in a non-standard location, set the `CDP_PORT_FILE` environment variable to the full path.
+The CLI auto-detects Chrome, Chromium, Brave, Edge, and Vivaldi on macOS and Linux, and Chrome, Brave, and Edge on Windows. If your browser stores `DevToolsActivePort` in a non-standard location, set the `CDP_PORT_FILE` environment variable to the full path.
 
 ## Usage
 
@@ -45,18 +45,18 @@ scripts/cdp.mjs clickxy <target> <x> <y>          # click at CSS pixel coordinat
 scripts/cdp.mjs type   <target> "text"            # type at focused element (works in cross-origin iframes)
 scripts/cdp.mjs loadall <target> "selector"       # click "load more" until gone
 scripts/cdp.mjs evalraw <target> <method> [json]  # raw CDP command passthrough
-scripts/cdp.mjs open   [url]                      # open new tab (triggers Allow prompt)
-scripts/cdp.mjs stop   [target]                   # stop daemon(s)
+scripts/cdp.mjs open   [url]                      # open new tab via the browser daemon
+scripts/cdp.mjs stop                             # stop the browser daemon
 ```
 
 `<target>` is a unique prefix of the targetId shown by `list`.
 
 ## Why not chrome-devtools-mcp?
 
-[chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp) reconnects on every command, so Chrome's "Allow debugging" modal can re-appear repeatedly and target enumeration times out with many tabs open. `chrome-cdp` holds one persistent daemon per tab — the modal fires once, and it handles 100+ tabs reliably.
+[chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp) reconnects on every command, so Chrome's "Allow debugging" modal can re-appear repeatedly and target enumeration times out with many tabs open. `chrome-cdp` holds one persistent browser daemon with a single CDP WebSocket connection, so the modal fires once per Chrome session and it handles 100+ tabs reliably.
 
 ## How it works
 
-Connects directly to Chrome's remote debugging WebSocket — no Puppeteer, no intermediary. On first access to a tab, a lightweight background daemon is spawned that holds the session open. Chrome's "Allow debugging" modal appears once per tab; subsequent commands reuse the daemon silently. Daemons auto-exit after 20 minutes of inactivity.
+Connects directly to Chrome's remote debugging WebSocket — no Puppeteer, no intermediary. A lightweight browser daemon keeps one CDP connection alive and manages tab sessions behind the scenes. Chrome's "Allow debugging" modal appears once per Chrome session; subsequent commands reuse the daemon silently. The daemon lives until Chrome disconnects or you run `scripts/cdp.mjs stop`.
 
 This approach is also why it handles 100+ open tabs reliably, where tools built on Puppeteer often time out during target enumeration.

--- a/docs/plans/2026-06-01-001-feat-cdp-observability-inspect-plan.md
+++ b/docs/plans/2026-06-01-001-feat-cdp-observability-inspect-plan.md
@@ -1,0 +1,165 @@
+---
+title: "feat: Add CDP observability and lightweight inspect"
+type: feat
+status: active
+date: 2026-06-01
+---
+
+# feat: Add CDP observability and lightweight inspect
+
+## Summary
+
+Add two agent-facing capabilities to the Chrome CDP CLI: a `stats` command for daemon and command-cost observability, and an `inspect` command that gives Codex a lightweight page summary before it reaches for heavier `snap`, `html`, or `shot` commands.
+
+---
+
+## Problem Frame
+
+The current single browser daemon improves the Chrome authorization experience, but resource complaints are still hard to diagnose because the CLI has no first-class view into daemon lifetime, session count, command timings, or recent slow operations. The existing page-observation path also encourages agents to use heavyweight commands like full accessibility snapshots or screenshots when a smaller semantic summary would often be enough.
+
+The plan targets macOS live-Chrome automation as the primary use case while preserving the current cross-platform CLI shape already present in `skills/chrome-cdp/scripts/cdp.mjs`.
+
+---
+
+## Requirements
+
+**Observability**
+
+- R1. The CLI exposes a `stats` command that works through the browser daemon and reports daemon health, lifetime, session count, page count, recent command timings, and slow command summaries.
+- R2. Command timing is recorded inside the daemon for all daemon-handled commands without changing successful command output for existing commands.
+- R3. `stats` must be useful when diagnosing local dev server slowdowns by separating daemon-side cost from Chrome/page cost as much as the current process can observe.
+
+**Lightweight inspection**
+
+- R4. The CLI exposes an `inspect <target> [selector]` command that returns a compact, agent-friendly page summary without calling `Accessibility.getFullAXTree` or `Page.captureScreenshot`.
+- R5. `inspect` includes enough context for common automation decisions: page title, URL, ready state, focused element, visible controls, links, inputs, forms, headings, and a bounded text sample.
+- R6. `inspect [selector]` scopes the summary to a matching element when provided and reports a clear error when no element matches.
+
+**Documentation and agent behavior**
+
+- R7. `README.md` and `skills/chrome-cdp/SKILL.md` document the new commands.
+- R8. The skill guidance tells agents to prefer `inspect` before `snap`, `html`, or `shot` unless the task specifically requires full accessibility structure, raw markup, or visual evidence.
+
+---
+
+## Key Technical Decisions
+
+- **Keep observability inside the daemon:** Timing and session data should live in `runBrowserDaemon()` because it is the long-lived process that sees command execution, session attachment, and target cleanup. One-shot CLI wrappers cannot reliably reconstruct that history.
+- **Use lightweight runtime evaluation for `inspect`:** Implement `inspect` with a bounded `Runtime.evaluate` script that reads DOM state and visible interactive elements. This avoids the known high-cost CDP paths behind `snap` and `shot` while still giving Codex a useful page map.
+- **Return human-readable text, not a new JSON default:** The existing CLI commands primarily return readable text. `stats` and `inspect` should follow that pattern so they are immediately usable by agents and humans. If raw JSON is needed later, add it deliberately as a separate flag or command variant.
+- **Measure command duration around handler execution:** Wrap `handleCommand()` execution so all command paths, including errors, can be timed consistently. The timing store should be bounded to avoid the daemon becoming an unbounded log.
+- **Do not add OS-level CPU sampling in the first pass:** Cross-platform CPU sampling introduces platform-specific process inspection and ambiguity. Start with daemon-local metrics and command durations, then add OS process sampling only if `stats` proves insufficient.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  CLI[CLI command] --> Socket[Browser daemon socket]
+  Socket --> Handler[handleCommand]
+  Handler --> Timer[Command timing wrapper]
+  Handler --> Session[getSession for target commands]
+  Session --> CDP[Chrome CDP WebSocket]
+  Handler --> Stats[stats: daemon state and timing history]
+  Handler --> Inspect[inspect: bounded Runtime.evaluate page summary]
+  Timer --> History[Bounded recent command history]
+```
+
+The new commands should fit the existing command-dispatch model: CLI input is normalized in `main()`, sent over the daemon socket, handled in `runBrowserDaemon()`, then rendered as text on stdout. `stats` is browser-level and does not require a target. `inspect` is target-level and should reuse the same target-prefix resolution path as `snap`, `html`, and `eval`.
+
+---
+
+## Implementation Units
+
+### U1. Add daemon-local command metrics
+
+- **Goal:** Record enough runtime state to make `stats` meaningful without changing existing command outputs.
+- **Requirements:** R1, R2, R3
+- **Dependencies:** None
+- **Files:** `skills/chrome-cdp/scripts/cdp.mjs`
+- **Approach:** Add daemon-start timestamp, a bounded recent-command history, and helper functions for recording command name, target prefix or target ID when available, duration, success/failure, and error message summary. Wrap command execution inside `handleCommand()` so all paths are measured consistently. Track session count from the existing `sessions` map and page count via `getPages(cdp)` when `stats` is requested.
+- **Patterns to follow:** Existing `handleCommand()` switch in `runBrowserDaemon()` and existing human-readable formatting helpers such as `formatPageList()`.
+- **Test scenarios:**
+  - Run `list`, then `stats`; verify `stats` reports daemon uptime, recent command history including `list`, and no error.
+  - Run a command that fails, then `stats`; verify the failed command is recorded with failure status without breaking the original error behavior.
+  - Run more commands than the history limit; verify old entries are dropped and memory stays bounded.
+  - With no target-specific commands run yet, verify `stats` still renders with session count `0` or the current actual session count.
+- **Verification:** `node --check skills/chrome-cdp/scripts/cdp.mjs` passes, and manual CLI output is stable for pre-existing commands.
+
+### U2. Add `stats` CLI and daemon command
+
+- **Goal:** Expose daemon observability as a first-class CLI command.
+- **Requirements:** R1, R3, R7
+- **Dependencies:** U1
+- **Files:** `skills/chrome-cdp/scripts/cdp.mjs`, `README.md`, `skills/chrome-cdp/SKILL.md`
+- **Approach:** Add `stats` to the CLI command handling as a browser-level command that starts or reuses the browser daemon, sends `{ cmd: "stats" }`, and prints the daemon's formatted result. The daemon-side `stats` branch should report uptime, PID, runtime directory, socket path, session count, page count, recent command count, slowest recent commands, and last error if present.
+- **Patterns to follow:** Existing `list` command path for browser-level daemon commands, but avoid the extra `list_raw` round trip unless `stats` needs fresh page count.
+- **Test scenarios:**
+  - Run `scripts/cdp.mjs stats` when no daemon is running; verify it starts the daemon and prints stats.
+  - Run `scripts/cdp.mjs stats` after several target commands; verify command history and slow-command summary update.
+  - Run `scripts/cdp.mjs stop`, then `stats`; verify a new daemon can start cleanly.
+  - Verify `help` output and docs list `stats` accurately.
+- **Verification:** Manual `stats` output should be concise enough to paste into a debugging conversation and should not expose page contents beyond command names and target IDs.
+
+### U3. Add lightweight `inspect` page summary
+
+- **Goal:** Provide a low-cost default page-observation command for agent automation.
+- **Requirements:** R4, R5, R6
+- **Dependencies:** None
+- **Files:** `skills/chrome-cdp/scripts/cdp.mjs`
+- **Approach:** Add `inspectStr(cdp, sid, selector)` using `Runtime.evaluate` with `returnByValue: true`. The evaluated script should select either `document` or the requested element, compute visibility using bounding boxes and computed styles, and return a bounded object containing title, URL, ready state, active element, headings, visible buttons, links, inputs, textareas, selects, forms, and a text sample. Keep counts and text lengths capped so large app pages do not produce huge output.
+- **Patterns to follow:** Existing `htmlStr()` selector handling and `evalStr()` result conversion, but use an explicit object result rather than asking users to write their own eval expression.
+- **Test scenarios:**
+  - Inspect a simple page; verify title, URL, heading, link, and text sample are present.
+  - Inspect a page with buttons, inputs, textareas, and selects; verify each control appears with useful labels or attributes.
+  - Inspect with a selector that matches a subsection; verify output is scoped to that element.
+  - Inspect with a selector that does not match; verify a clear user-facing error.
+  - Inspect a large local app page; verify output remains bounded and does not dump the full DOM.
+- **Verification:** `inspect` should not call `Accessibility.getFullAXTree`, `Page.captureScreenshot`, or `document.documentElement.outerHTML`.
+
+### U4. Wire `inspect` into CLI usage and agent guidance
+
+- **Goal:** Make `inspect` the recommended first observation step for Codex-style automation.
+- **Requirements:** R7, R8
+- **Dependencies:** U3
+- **Files:** `skills/chrome-cdp/scripts/cdp.mjs`, `README.md`, `skills/chrome-cdp/SKILL.md`
+- **Approach:** Add `inspect` to `NEEDS_TARGET`, daemon command dispatch, usage text, README command list, and skill command list. Update the skill tips to say: start with `list`, use `inspect` for lightweight page state, escalate to `snap` for accessibility structure, `html` for raw markup, and `shot` for visual evidence.
+- **Patterns to follow:** Existing command documentation style in `README.md` and `skills/chrome-cdp/SKILL.md`.
+- **Test scenarios:**
+  - Run `scripts/cdp.mjs inspect <target>` after `list`; verify target prefix resolution works.
+  - Run `scripts/cdp.mjs inspect <target> <selector>` with a selector containing shell-sensitive characters when quoted; verify it reaches the daemon intact.
+  - Verify `scripts/cdp.mjs help` documents `inspect` and that the skill doc suggests it before `snap`.
+- **Verification:** Agent-facing docs should clearly steer lower-cost behavior without removing access to existing full-fidelity commands.
+
+---
+
+## Scope Boundaries
+
+- `stats` will report daemon-local and CDP-observable information. It will not attempt full Activity Monitor replacement or per-Chrome-renderer attribution in this pass.
+- `inspect` will summarize DOM-visible page state. It will not replace `snap` for full accessibility tree debugging, `html` for raw markup inspection, or `shot` for visual layout verification.
+- Selector or clip screenshot support remains deferred until real usage shows screenshots are a high-frequency bottleneck.
+- Daemon idle timeout remains deferred because current measurements show the single daemon is light when idle.
+
+---
+
+## System-Wide Impact
+
+The CLI command surface changes, and the skill guidance changes how agents should explore pages. Existing commands should remain backward compatible. The new default behavior should reduce unnecessary use of expensive inspection primitives during local Chrome automation, especially on dev-server pages where page rendering, HMR, and CDP commands can compound.
+
+---
+
+## Risks & Dependencies
+
+- **Inspect summary can become too noisy:** Bound list sizes, text lengths, and section counts from the first implementation.
+- **Stats can imply precision it does not have:** Label daemon-local metrics clearly and avoid pretending to attribute Chrome renderer CPU without OS-level sampling.
+- **Runtime evaluation can fail on unusual pages:** Return clear errors and preserve the ability to fall back to `snap`, `html`, or `evalraw`.
+- **Docs may oversteer agents away from useful full-fidelity commands:** Phrase guidance as escalation order, not prohibition.
+
+---
+
+## Sources & Research
+
+- `skills/chrome-cdp/scripts/cdp.mjs` already centralizes CDP command handling in `runBrowserDaemon()`, making it the right place for command metrics and `stats`.
+- `skills/chrome-cdp/scripts/cdp.mjs` currently implements `snap` with `Accessibility.getFullAXTree` and `shot` with `Page.captureScreenshot`, which are the heavier paths this plan avoids for the new `inspect` command.
+- `README.md` and `skills/chrome-cdp/SKILL.md` already document commands in parallel; both should be updated whenever the CLI surface changes.

--- a/skills/chrome-cdp/SKILL.md
+++ b/skills/chrome-cdp/SKILL.md
@@ -38,6 +38,22 @@ Captures the **viewport only**. Scroll first with `eval` if you need content bel
 scripts/cdp.mjs snap <target>
 ```
 
+### Lightweight page inspection
+
+```bash
+scripts/cdp.mjs inspect <target> [selector]
+```
+
+Use `inspect` first for page state: title, URL, ready state, focus, visible controls, links, inputs, forms, headings, and a bounded text sample. Escalate to `snap` for full accessibility structure, `html` for raw markup, or `shot` for visual evidence.
+
+### Daemon stats
+
+```bash
+scripts/cdp.mjs stats
+```
+
+Shows browser daemon uptime, session/page counts, and recent command timings. Use this when local Chrome automation feels slow or resource-heavy.
+
 ### Evaluate JavaScript
 
 ```bash
@@ -50,6 +66,7 @@ scripts/cdp.mjs eval <target> <expr>
 
 ```bash
 scripts/cdp.mjs html    <target> [selector]   # full page or element HTML
+scripts/cdp.mjs inspect <target> [selector]   # lightweight page summary
 scripts/cdp.mjs nav     <target> <url>         # navigate and wait for load
 scripts/cdp.mjs net     <target>               # resource timing entries
 scripts/cdp.mjs click   <target> <selector>    # click element by CSS selector
@@ -58,6 +75,7 @@ scripts/cdp.mjs type    <target> <text>         # Input.insertText at current fo
 scripts/cdp.mjs loadall <target> <selector> [ms]  # click "load more" until gone (default 1500ms between clicks)
 scripts/cdp.mjs evalraw <target> <method> [json]  # raw CDP command passthrough
 scripts/cdp.mjs open    [url]                  # open new tab via the browser daemon
+scripts/cdp.mjs stats                          # daemon health and recent command timings
 scripts/cdp.mjs stop                           # stop the browser daemon
 ```
 
@@ -73,6 +91,7 @@ CSS px = screenshot image px / DPR
 
 ## Tips
 
-- Prefer `snap --compact` over `html` for page structure.
+- Prefer `inspect` for first-pass page state; use `snap` only when you need the full accessibility tree.
 - Use `type` (not eval) to enter text in cross-origin iframes — `click`/`clickxy` to focus first, then `type`.
+- Prefer one combined `eval` over many small `eval` calls when collecting structured page data.
 - Chrome shows an "Allow debugging" modal once per Chrome session. A background browser daemon keeps the CDP connection alive so subsequent commands need no further approval until Chrome disconnects or you run `stop`.

--- a/skills/chrome-cdp/SKILL.md
+++ b/skills/chrome-cdp/SKILL.md
@@ -12,6 +12,7 @@ Lightweight Chrome DevTools Protocol CLI. Connects directly via WebSocket — no
 - Chrome (or Chromium, Brave, Edge, Vivaldi) with remote debugging enabled: open `chrome://inspect/#remote-debugging` and toggle the switch
 - Node.js 22+ (uses built-in WebSocket)
 - If your browser's `DevToolsActivePort` is in a non-standard location, set `CDP_PORT_FILE` to its full path
+- Set `CDP_HOST` if Chrome's debugging socket is not reachable on `127.0.0.1`
 
 ## Commands
 
@@ -56,8 +57,8 @@ scripts/cdp.mjs clickxy <target> <x> <y>       # click at CSS pixel coords
 scripts/cdp.mjs type    <target> <text>         # Input.insertText at current focus; works in cross-origin iframes unlike eval
 scripts/cdp.mjs loadall <target> <selector> [ms]  # click "load more" until gone (default 1500ms between clicks)
 scripts/cdp.mjs evalraw <target> <method> [json]  # raw CDP command passthrough
-scripts/cdp.mjs open    [url]                  # open new tab (each triggers Allow prompt)
-scripts/cdp.mjs stop    [target]               # stop daemon(s)
+scripts/cdp.mjs open    [url]                  # open new tab via the browser daemon
+scripts/cdp.mjs stop                           # stop the browser daemon
 ```
 
 ## Coordinates
@@ -74,4 +75,4 @@ CSS px = screenshot image px / DPR
 
 - Prefer `snap --compact` over `html` for page structure.
 - Use `type` (not eval) to enter text in cross-origin iframes — `click`/`clickxy` to focus first, then `type`.
-- Chrome shows an "Allow debugging" modal once per tab on first access. A background daemon keeps the session alive so subsequent commands need no further approval. Daemons auto-exit after 20 minutes of inactivity.
+- Chrome shows an "Allow debugging" modal once per Chrome session. A background browser daemon keeps the CDP connection alive so subsequent commands need no further approval until Chrome disconnects or you run `stop`.

--- a/skills/chrome-cdp/scripts/cdp.mjs
+++ b/skills/chrome-cdp/scripts/cdp.mjs
@@ -19,6 +19,7 @@ const NAVIGATION_TIMEOUT = 30000;
 const DAEMON_CONNECT_RETRIES = 20;
 const DAEMON_CONNECT_DELAY = 300;
 const MIN_TARGET_PREFIX_LEN = 8;
+const COMMAND_HISTORY_LIMIT = 50;
 const IS_WINDOWS = process.platform === 'win32';
 if (!IS_WINDOWS) process.umask(0o077);
 const RUNTIME_DIR = IS_WINDOWS
@@ -219,6 +220,21 @@ function formatPageList(pages) {
   }).join('\n');
 }
 
+function formatDuration(ms) {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${Math.round(ms / 100) / 10}s`;
+}
+
+function formatUptime(ms) {
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours > 0) return `${hours}h ${minutes}m ${seconds}s`;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
+}
+
 function shouldShowAxNode(node, compact = false) {
   const role = node.role?.value || '';
   const name = node.name?.value ?? '';
@@ -340,6 +356,142 @@ async function htmlStr(cdp, sid, selector) {
     ? `document.querySelector(${JSON.stringify(selector)})?.outerHTML || 'Element not found'`
     : `document.documentElement.outerHTML`;
   return evalStr(cdp, sid, expr);
+}
+
+function formatElementSummary(item) {
+  const parts = [`<${item.tag.toLowerCase()}>`];
+  if (item.label) parts.push(JSON.stringify(item.label));
+  if (item.type) parts.push(`type=${item.type}`);
+  if (item.name) parts.push(`name=${item.name}`);
+  if (item.placeholder) parts.push(`placeholder=${JSON.stringify(item.placeholder)}`);
+  if (item.href) parts.push(`href=${item.href}`);
+  return parts.join(' ');
+}
+
+async function inspectStr(cdp, sid, selector) {
+  const expr = `
+    (function() {
+      const selector = ${JSON.stringify(selector || '')};
+      const root = selector ? document.querySelector(selector) : document.body;
+      if (!root) return { ok: false, error: 'Element not found: ' + selector };
+
+      const MAX_TEXT = 700;
+      const MAX_ITEMS = 20;
+      const textOf = (el, max = 90) => (el.innerText || el.textContent || '')
+        .replace(/\\s+/g, ' ')
+        .trim()
+        .slice(0, max);
+      const attr = (el, name) => el.getAttribute(name) || '';
+      const labelFor = (el) => {
+        const aria = attr(el, 'aria-label');
+        if (aria) return aria.trim();
+        const labelledBy = attr(el, 'aria-labelledby');
+        if (labelledBy) {
+          const text = labelledBy.split(/\\s+/).map(id => document.getElementById(id)?.innerText || '').join(' ').trim();
+          if (text) return text.slice(0, 90);
+        }
+        if (el.id) {
+          const label = document.querySelector('label[for="' + CSS.escape(el.id) + '"]');
+          if (label) return textOf(label);
+        }
+        return textOf(el);
+      };
+      const isVisible = (el) => {
+        if (!el || !(el instanceof Element)) return false;
+        const rect = el.getBoundingClientRect();
+        const style = getComputedStyle(el);
+        return rect.width > 0 && rect.height > 0 &&
+          style.visibility !== 'hidden' &&
+          style.display !== 'none' &&
+          Number(style.opacity || '1') > 0;
+      };
+      const summarize = (el) => {
+        const rect = el.getBoundingClientRect();
+        return {
+          tag: el.tagName,
+          label: labelFor(el),
+          type: attr(el, 'type'),
+          name: attr(el, 'name'),
+          placeholder: attr(el, 'placeholder'),
+          href: attr(el, 'href'),
+          id: attr(el, 'id'),
+          classes: attr(el, 'class').split(/\\s+/).filter(Boolean).slice(0, 4).join('.'),
+          disabled: !!el.disabled || attr(el, 'aria-disabled') === 'true',
+          rect: {
+            x: Math.round(rect.x),
+            y: Math.round(rect.y),
+            w: Math.round(rect.width),
+            h: Math.round(rect.height),
+          },
+        };
+      };
+      const takeVisible = (query) => [
+          ...(root.matches?.(query) ? [root] : []),
+          ...Array.from(root.querySelectorAll(query)),
+        ]
+        .filter((el, idx, list) => list.indexOf(el) === idx)
+        .filter(isVisible)
+        .slice(0, MAX_ITEMS)
+        .map(summarize);
+      const active = document.activeElement && document.activeElement !== document.body
+        ? summarize(document.activeElement)
+        : null;
+
+      return {
+        ok: true,
+        scopedTo: selector || 'document.body',
+        title: document.title,
+        url: location.href,
+        readyState: document.readyState,
+        active,
+        headings: takeVisible('h1,h2,h3'),
+        buttons: takeVisible('button,[role="button"],input[type="button"],input[type="submit"]'),
+        links: takeVisible('a[href]'),
+        inputs: takeVisible('input:not([type="button"]):not([type="submit"]),textarea,select'),
+        forms: takeVisible('form'),
+        text: textOf(root, MAX_TEXT),
+        counts: {
+          buttons: root.querySelectorAll('button,[role="button"],input[type="button"],input[type="submit"]').length,
+          links: root.querySelectorAll('a[href]').length,
+          inputs: root.querySelectorAll('input:not([type="button"]):not([type="submit"]),textarea,select').length,
+          forms: root.querySelectorAll('form').length,
+        },
+      };
+    })()
+  `;
+  const raw = await evalStr(cdp, sid, expr);
+  const data = JSON.parse(raw);
+  if (!data.ok) throw new Error(data.error);
+
+  const lines = [
+    `Title: ${data.title || '(untitled)'}`,
+    `URL: ${data.url}`,
+    `Ready state: ${data.readyState}`,
+    `Scope: ${data.scopedTo}`,
+  ];
+  if (data.active) lines.push(`Focused: ${formatElementSummary(data.active)}`);
+
+  const addSection = (label, items, total) => {
+    lines.push('');
+    lines.push(`${label} (${items.length}${total > items.length ? ` of ${total}` : ''})`);
+    if (items.length === 0) {
+      lines.push('  (none visible)');
+      return;
+    }
+    for (const item of items) lines.push(`  - ${formatElementSummary(item)}`);
+  };
+
+  addSection('Headings', data.headings, data.headings.length);
+  addSection('Buttons', data.buttons, data.counts.buttons);
+  addSection('Links', data.links, data.counts.links);
+  addSection('Inputs', data.inputs, data.counts.inputs);
+  addSection('Forms', data.forms, data.counts.forms);
+  if (data.text) {
+    lines.push('');
+    lines.push('Text sample');
+    lines.push(data.text);
+  }
+  return lines.join('\n');
 }
 
 async function waitForDocumentReady(cdp, sid, timeoutMs = NAVIGATION_TIMEOUT) {
@@ -496,6 +648,50 @@ async function runBrowserDaemon() {
   // sessions: targetId → sessionId
   // Populated via Target.attachedToTarget events (from setAutoAttach) + fallback attachToTarget
   const sessions = new Map();
+  const startedAt = Date.now();
+  const commandHistory = [];
+
+  function recordCommand(entry) {
+    commandHistory.push(entry);
+    if (commandHistory.length > COMMAND_HISTORY_LIMIT) commandHistory.shift();
+  }
+
+  async function statsStr() {
+    const pages = await getPages(cdp).catch(() => []);
+    const slowest = [...commandHistory]
+      .sort((a, b) => b.durationMs - a.durationMs)
+      .slice(0, 5);
+    const recent = commandHistory.slice(-10);
+    const lastError = [...commandHistory].reverse().find(entry => !entry.ok);
+    const lines = [
+      `Browser daemon PID: ${process.pid}`,
+      `Uptime: ${formatUptime(Date.now() - startedAt)}`,
+      `Runtime dir: ${RUNTIME_DIR}`,
+      `Socket: ${BROWSER_SOCK}`,
+      `Sessions: ${sessions.size}`,
+      `Pages: ${pages.length}`,
+      `Recent commands: ${commandHistory.length}/${COMMAND_HISTORY_LIMIT}`,
+      `Last error: ${lastError ? `${lastError.cmd}${lastError.targetId ? ` target=${lastError.targetId.slice(0, 8)}` : ''}: ${lastError.error}` : '(none)'}`,
+    ];
+
+    const renderEntry = (entry) => {
+      const target = entry.targetId ? ` target=${entry.targetId.slice(0, 8)}` : '';
+      const status = entry.ok ? 'ok' : 'error';
+      const error = entry.error ? ` (${entry.error})` : '';
+      return `  - ${entry.cmd}${target}: ${formatDuration(entry.durationMs)} ${status}${error}`;
+    };
+
+    lines.push('');
+    lines.push('Slowest recent commands');
+    if (slowest.length === 0) lines.push('  (none yet)');
+    else for (const entry of slowest) lines.push(renderEntry(entry));
+
+    lines.push('');
+    lines.push('Last commands');
+    if (recent.length === 0) lines.push('  (none yet)');
+    else for (const entry of recent) lines.push(renderEntry(entry));
+    return lines.join('\n');
+  }
 
   // Shutdown helpers
   let alive = true;
@@ -575,7 +771,7 @@ async function runBrowserDaemon() {
   }
 
   // Handle a command; targetId is required for tab-specific commands
-  async function handleCommand({ cmd, targetId, args }) {
+  async function runCommand({ cmd, targetId, args }) {
     try {
       let result;
       switch (cmd) {
@@ -587,6 +783,10 @@ async function runBrowserDaemon() {
         case 'list_raw': {
           const pages = await getPages(cdp);
           result = JSON.stringify(pages);
+          break;
+        }
+        case 'stats': {
+          result = await statsStr();
           break;
         }
         case 'open': {
@@ -612,6 +812,7 @@ async function runBrowserDaemon() {
           const run = async (sessionId) => {
             switch (cmd) {
               case 'snap': case 'snapshot': return snapshotStr(cdp, sessionId, true);
+              case 'inspect': return inspectStr(cdp, sessionId, args[0]);
               case 'eval': return evalStr(cdp, sessionId, args[0]);
               case 'shot': case 'screenshot': return shotStr(cdp, sessionId, args[0], targetId);
               case 'html': return htmlStr(cdp, sessionId, args[0]);
@@ -644,6 +845,21 @@ async function runBrowserDaemon() {
     } catch (e) {
       return { ok: false, error: e.message };
     }
+  }
+
+  async function handleCommand(req) {
+    const started = Date.now();
+    const res = await runCommand(req);
+    if (req.cmd !== 'list_raw') {
+      recordCommand({
+        cmd: req.cmd,
+        targetId: req.targetId,
+        durationMs: Date.now() - started,
+        ok: !!res.ok,
+        error: res.ok ? '' : String(res.error || '').slice(0, 120),
+      });
+    }
+    return res;
   }
 
   // Unix socket server — NDJSON protocol
@@ -792,6 +1008,8 @@ const USAGE = `cdp - lightweight Chrome DevTools Protocol CLI (no Puppeteer)
 Usage: cdp <command> [args]
 
   list                              List open pages (shows unique target prefixes)
+  stats                             Show browser daemon health and recent command timings
+  inspect <target> [selector]       Lightweight page summary (optionally scoped to CSS selector)
   snap  <target>                    Accessibility tree snapshot
   eval  <target> <expr>             Evaluate JS expression
   shot  <target> [file]             Screenshot (default: screenshot-<target>.png in runtime dir); prints coordinate mapping
@@ -835,13 +1053,13 @@ DAEMON IPC (for advanced use / scripting)
     Request:  {"id":<number>, "cmd":"<command>", "targetId":"<id>", "args":["arg1","arg2",...]}
     Response: {"id":<number>, "ok":true,  "result":"<string>"}
            or {"id":<number>, "ok":false, "error":"<message>"}
-  Commands mirror the CLI: snap, eval, shot, html, nav, net, click, clickxy,
-  type, loadall, evalraw, stop. Use evalraw to send arbitrary CDP methods.
+  Commands mirror the CLI: stats, inspect, snap, eval, shot, html, nav, net,
+  click, clickxy, type, loadall, evalraw, stop. Use evalraw to send arbitrary CDP methods.
   The socket disappears when Chrome disconnects or after "cdp stop".
 `;
 
 const NEEDS_TARGET = new Set([
-  'snap','snapshot','eval','shot','screenshot','html','nav','navigate',
+  'inspect','snap','snapshot','eval','shot','screenshot','html','nav','navigate',
   'net','network','click','clickxy','type','loadall','evalraw',
 ]);
 
@@ -863,6 +1081,14 @@ async function main() {
     const conn2 = await getOrStartBrowserDaemon();
     const raw = await sendCommand(conn2, { cmd: 'list_raw', args: [] });
     if (raw.ok) writeFileSync(PAGES_CACHE, raw.result, { mode: 0o600 });
+    console.log(response.result);
+    return;
+  }
+
+  if (cmd === 'stats') {
+    const conn = await getOrStartBrowserDaemon();
+    const response = await sendCommand(conn, { cmd: 'stats', args: [] });
+    if (!response.ok) { console.error('Error:', response.error); process.exit(1); }
     console.log(response.result);
     return;
   }

--- a/skills/chrome-cdp/scripts/cdp.mjs
+++ b/skills/chrome-cdp/scripts/cdp.mjs
@@ -3,9 +3,10 @@
 // Uses raw CDP over WebSocket, no Puppeteer dependency.
 // Requires Node 22+ (built-in WebSocket).
 //
-// Per-tab persistent daemon: page commands go through a daemon that holds
-// the CDP session open. Chrome's "Allow debugging" modal fires once per
-// daemon (= once per tab). Daemons auto-exit after 20min idle.
+// Single browser daemon: all page commands go through one daemon that holds
+// a single CDP WebSocket connection to Chrome. Chrome's "Allow debugging"
+// modal fires once per daemon (= once per Chrome session). Daemon lives
+// until Chrome disconnects or "cdp stop" is called.
 
 import { readFileSync, writeFileSync, unlinkSync, existsSync, mkdirSync } from 'fs';
 import { homedir } from 'os';
@@ -15,7 +16,6 @@ import net from 'net';
 
 const TIMEOUT = 15000;
 const NAVIGATION_TIMEOUT = 30000;
-const IDLE_TIMEOUT = 20 * 60 * 1000;
 const DAEMON_CONNECT_RETRIES = 20;
 const DAEMON_CONNECT_DELAY = 300;
 const MIN_TARGET_PREFIX_LEN = 8;
@@ -29,11 +29,10 @@ const RUNTIME_DIR = IS_WINDOWS
 try { mkdirSync(RUNTIME_DIR, { recursive: true, mode: 0o700 }); } catch {}
 const PAGES_CACHE = resolve(RUNTIME_DIR, 'pages.json');
 
-function sockPath(targetId) {
-  return IS_WINDOWS
-    ? `\\\\.\\pipe\\cdp-${targetId}`
-    : resolve(RUNTIME_DIR, `cdp-${targetId}.sock`);
-}
+// Single browser-level daemon socket (one per Chrome session)
+const BROWSER_SOCK = IS_WINDOWS
+  ? `\\\\.\\pipe\\cdp-browser`
+  : resolve(RUNTIME_DIR, 'cdp-browser.sock');
 
 function getWsUrl() {
   const home = homedir();
@@ -480,29 +479,23 @@ async function evalRawStr(cdp, sid, method, paramsJson) {
 }
 
 // ---------------------------------------------------------------------------
-// Per-tab daemon
+// Browser-level daemon (single WebSocket connection, manages all tab sessions)
 // ---------------------------------------------------------------------------
 
-async function runDaemon(targetId) {
-  const sp = sockPath(targetId);
+async function runBrowserDaemon() {
+  const sp = BROWSER_SOCK;
 
   const cdp = new CDP();
   try {
     await cdp.connect(getWsUrl());
   } catch (e) {
-    process.stderr.write(`Daemon: cannot connect to Chrome: ${e.message}\n`);
+    process.stderr.write(`Browser daemon: cannot connect to Chrome: ${e.message}\n`);
     process.exit(1);
   }
 
-  let sessionId;
-  try {
-    const res = await cdp.send('Target.attachToTarget', { targetId, flatten: true });
-    sessionId = res.sessionId;
-  } catch (e) {
-    process.stderr.write(`Daemon: attach failed: ${e.message}\n`);
-    cdp.close();
-    process.exit(1);
-  }
+  // sessions: targetId → sessionId
+  // Populated via Target.attachedToTarget events (from setAutoAttach) + fallback attachToTarget
+  const sessions = new Map();
 
   // Shutdown helpers
   let alive = true;
@@ -515,27 +508,74 @@ async function runDaemon(targetId) {
     process.exit(0);
   }
 
-  // Exit if target goes away or Chrome disconnects
-  cdp.onEvent('Target.targetDestroyed', (params) => {
-    if (params.targetId === targetId) shutdown();
-  });
-  cdp.onEvent('Target.detachedFromTarget', (params) => {
-    if (params.sessionId === sessionId) shutdown();
-  });
+  // Exit if Chrome disconnects
   cdp.onClose(() => shutdown());
   process.on('SIGTERM', shutdown);
   process.on('SIGINT', shutdown);
 
-  // Idle timer
-  let idleTimer = setTimeout(shutdown, IDLE_TIMEOUT);
-  function resetIdle() {
-    clearTimeout(idleTimer);
-    idleTimer = setTimeout(shutdown, IDLE_TIMEOUT);
+  // sessions: targetId → sessionId, populated by the two-level setAutoAttach below
+  // This mirrors exactly what Puppeteer does, which is why chrome-devtools-mcp
+  // never triggers the "Allow debugging?" popup.
+
+  // Level 2: when a page is attached from a tab session, store its sessionId
+  cdp.onEvent('Target.attachedToTarget', async (params) => {
+    const { sessionId, targetInfo } = params;
+    if (!sessionId || !targetInfo?.targetId) return;
+
+    if (targetInfo.type === 'tab') {
+      // Level 1 fired: a tab target was attached at browser level.
+      // Now set up page-level autoAttach on THIS tab's session (Level 2).
+      // Pages attached this way don't trigger the Allow popup.
+      try {
+        await cdp.send('Target.setAutoAttach', {
+          autoAttach: true,
+          waitForDebuggerOnStart: false,
+          flatten: true,
+          filter: [{}],
+        }, sessionId);
+      } catch {}
+    } else if (targetInfo.type === 'page') {
+      // Level 2 fired: a page was attached from a tab session → store it
+      sessions.set(targetInfo.targetId, sessionId);
+    }
+  });
+
+  // Clean up sessions when targets go away
+  cdp.onEvent('Target.targetDestroyed', (params) => {
+    sessions.delete(params.targetId);
+  });
+  cdp.onEvent('Target.detachedFromTarget', (params) => {
+    for (const [tid, sid] of sessions) {
+      if (sid === params.sessionId) { sessions.delete(tid); break; }
+    }
+  });
+
+  // Level 1: browser-level setAutoAttach, excluding page targets.
+  // Attach only to 'tab' targets (Chrome's tab wrapper) — same as Puppeteer.
+  // Direct browser→page attachment is what triggers the popup; this avoids it.
+  await cdp.send('Target.setAutoAttach', {
+    autoAttach: true,
+    waitForDebuggerOnStart: false,
+    flatten: true,
+    filter: [{ type: 'page', exclude: true }, {}],
+  });
+
+  // Get or wait for a session for a given targetId.
+  async function getSession(targetId) {
+    if (sessions.has(targetId)) return sessions.get(targetId);
+    // Wait up to 500ms for the two-level attach events to settle
+    for (let i = 0; i < 10; i++) {
+      await sleep(50);
+      if (sessions.has(targetId)) return sessions.get(targetId);
+    }
+    // Fallback for Chrome versions without 'tab' target support
+    const res = await cdp.send('Target.attachToTarget', { targetId, flatten: true });
+    sessions.set(targetId, res.sessionId);
+    return res.sessionId;
   }
 
-  // Handle a command
-  async function handleCommand({ cmd, args }) {
-    resetIdle();
+  // Handle a command; targetId is required for tab-specific commands
+  async function handleCommand({ cmd, targetId, args }) {
     try {
       let result;
       switch (cmd) {
@@ -549,19 +589,56 @@ async function runDaemon(targetId) {
           result = JSON.stringify(pages);
           break;
         }
-        case 'snap': case 'snapshot': result = await snapshotStr(cdp, sessionId, true); break;
-        case 'eval': result = await evalStr(cdp, sessionId, args[0]); break;
-        case 'shot': case 'screenshot': result = await shotStr(cdp, sessionId, args[0], targetId); break;
-        case 'html': result = await htmlStr(cdp, sessionId, args[0]); break;
-        case 'nav': case 'navigate': result = await navStr(cdp, sessionId, args[0]); break;
-        case 'net': case 'network': result = await netStr(cdp, sessionId); break;
-        case 'click': result = await clickStr(cdp, sessionId, args[0]); break;
-        case 'clickxy': result = await clickXyStr(cdp, sessionId, args[0], args[1]); break;
-        case 'type': result = await typeStr(cdp, sessionId, args[0]); break;
-        case 'loadall': result = await loadAllStr(cdp, sessionId, args[0], args[1] ? parseInt(args[1]) : 1500); break;
-        case 'evalraw': result = await evalRawStr(cdp, sessionId, args[0], args[1]); break;
+        case 'open': {
+          const url = args[0] || 'about:blank';
+          const { targetId } = await cdp.send('Target.createTarget', { url });
+          const pages = await getPages(cdp);
+          if (!pages.some(p => p.targetId === targetId)) {
+            pages.push({ targetId, title: url, url });
+          }
+          result = JSON.stringify({ targetId, pages });
+          break;
+        }
         case 'stop': return { ok: true, result: '', stopAfter: true };
-        default: return { ok: false, error: `Unknown command: ${cmd}` };
+        default: {
+          if (!targetId) return { ok: false, error: 'targetId required for this command' };
+          let sid;
+          try {
+            sid = await getSession(targetId);
+          } catch (e) {
+            return { ok: false, error: `Failed to attach to tab: ${e.message}` };
+          }
+          // Execute command; on session error, evict cache and retry once
+          const run = async (sessionId) => {
+            switch (cmd) {
+              case 'snap': case 'snapshot': return snapshotStr(cdp, sessionId, true);
+              case 'eval': return evalStr(cdp, sessionId, args[0]);
+              case 'shot': case 'screenshot': return shotStr(cdp, sessionId, args[0], targetId);
+              case 'html': return htmlStr(cdp, sessionId, args[0]);
+              case 'nav': case 'navigate': return navStr(cdp, sessionId, args[0]);
+              case 'net': case 'network': return netStr(cdp, sessionId);
+              case 'click': return clickStr(cdp, sessionId, args[0]);
+              case 'clickxy': return clickXyStr(cdp, sessionId, args[0], args[1]);
+              case 'type': return typeStr(cdp, sessionId, args[0]);
+              case 'loadall': return loadAllStr(cdp, sessionId, args[0], args[1] ? parseInt(args[1]) : 1500);
+              case 'evalraw': return evalRawStr(cdp, sessionId, args[0], args[1]);
+              default: throw new Error(`Unknown command: ${cmd}`);
+            }
+          };
+          try {
+            result = await run(sid);
+          } catch (e) {
+            // If session is stale, re-attach once
+            if (/session|Session|detach|Detach/.test(e.message)) {
+              sessions.delete(targetId);
+              sid = await getSession(targetId);
+              result = await run(sid);
+            } else {
+              throw e;
+            }
+          }
+          break;
+        }
       }
       return { ok: true, result: result ?? '' };
     } catch (e) {
@@ -571,7 +648,7 @@ async function runDaemon(targetId) {
 
   // Unix socket server — NDJSON protocol
   // Wire format: each message is one JSON object followed by \n (newline-delimited JSON).
-  // Request:  { "id": <number>, "cmd": "<command>", "args": ["arg1", "arg2", ...] }
+  // Request:  { "id": <number>, "cmd": "<command>", "targetId": "<id>", "args": ["arg1", ...] }
   // Response: { "id": <number>, "ok": <boolean>, "result": "<string>" }
   //           or { "id": <number>, "ok": false, "error": "<message>" }
   const server = net.createServer((conn) => {
@@ -599,7 +676,7 @@ async function runDaemon(targetId) {
   });
 
   server.on('error', (e) => {
-    process.stderr.write(`Daemon server listen failed: ${e.message}\n`);
+    process.stderr.write(`Browser daemon server listen failed: ${e.message}\n`);
     process.exit(1);
   });
 
@@ -619,16 +696,15 @@ function connectToSocket(sp) {
   });
 }
 
-async function getOrStartTabDaemon(targetId) {
-  const sp = sockPath(targetId);
-  // Try existing daemon
-  try { return await connectToSocket(sp); } catch {}
+async function getOrStartBrowserDaemon() {
+  // Try existing browser daemon
+  try { return await connectToSocket(BROWSER_SOCK); } catch {}
 
   // Clean stale socket
-  if (!IS_WINDOWS) try { unlinkSync(sp); } catch {}
+  if (!IS_WINDOWS) try { unlinkSync(BROWSER_SOCK); } catch {}
 
   // Spawn daemon
-  const child = spawn(process.execPath, [process.argv[1], '_daemon', targetId], {
+  const child = spawn(process.execPath, [process.argv[1], '_browser_daemon'], {
     detached: true,
     stdio: 'ignore',
   });
@@ -637,9 +713,9 @@ async function getOrStartTabDaemon(targetId) {
   // Wait for socket (includes time for user to click Allow)
   for (let i = 0; i < DAEMON_CONNECT_RETRIES; i++) {
     await sleep(DAEMON_CONNECT_DELAY);
-    try { return await connectToSocket(sp); } catch {}
+    try { return await connectToSocket(BROWSER_SOCK); } catch {}
   }
-  throw new Error('Daemon failed to start — did you click Allow in Chrome?');
+  throw new Error('Browser daemon failed to start — did you click Allow in Chrome?');
 }
 
 function sendCommand(conn, req) {
@@ -695,24 +771,15 @@ function sendCommand(conn, req) {
 }
 
 // ---------------------------------------------------------------------------
-// Stop daemons
+// Stop daemon
 // ---------------------------------------------------------------------------
 
-async function stopDaemons(targetPrefix) {
-  if (!existsSync(PAGES_CACHE)) return;
-  const pages = JSON.parse(readFileSync(PAGES_CACHE, 'utf8'));
-  const targets = targetPrefix
-    ? [resolvePrefix(targetPrefix, pages.map(p => p.targetId), 'target')]
-    : pages.map(p => p.targetId);
-
-  for (const targetId of targets) {
-    const sp = sockPath(targetId);
-    try {
-      const conn = await connectToSocket(sp);
-      await sendCommand(conn, { cmd: 'stop' });
-    } catch {
-      if (!IS_WINDOWS) try { unlinkSync(sp); } catch {}
-    }
+async function stopDaemon() {
+  try {
+    const conn = await connectToSocket(BROWSER_SOCK);
+    await sendCommand(conn, { cmd: 'stop' });
+  } catch {
+    if (!IS_WINDOWS) try { unlinkSync(BROWSER_SOCK); } catch {}
   }
 }
 
@@ -740,8 +807,7 @@ Usage: cdp <command> [args]
   evalraw <target> <method> [json]  Send a raw CDP command; returns JSON result
                                     e.g. evalraw <t> "DOM.getDocument" '{}'
   open  [url]                       Open a new tab (default: about:blank)
-                                    Note: each new tab triggers a fresh "Allow debugging?" prompt
-  stop  [target]                    Stop daemon(s)
+  stop                              Stop the browser daemon
 
 <target> is a unique targetId prefix from "cdp list". If a prefix is ambiguous,
 use more characters.
@@ -764,14 +830,14 @@ EVAL SAFETY NOTE
   collect all data in a single eval.
 
 DAEMON IPC (for advanced use / scripting)
-  Each tab runs a persistent daemon at Unix socket in the runtime dir (see below).
+  A single browser daemon runs at Unix socket in the runtime dir (see below).
   Protocol: newline-delimited JSON (one JSON object per line, UTF-8).
-    Request:  {"id":<number>, "cmd":"<command>", "args":["arg1","arg2",...]}
+    Request:  {"id":<number>, "cmd":"<command>", "targetId":"<id>", "args":["arg1","arg2",...]}
     Response: {"id":<number>, "ok":true,  "result":"<string>"}
            or {"id":<number>, "ok":false, "error":"<message>"}
   Commands mirror the CLI: snap, eval, shot, html, nav, net, click, clickxy,
   type, loadall, evalraw, stop. Use evalraw to send arbitrary CDP methods.
-  The socket disappears after 20 min of inactivity or when the tab closes.
+  The socket disappears when Chrome disconnects or after "cdp stop".
 `;
 
 const NEEDS_TARGET = new Set([
@@ -783,44 +849,39 @@ async function main() {
   const [cmd, ...args] = process.argv.slice(2);
 
   // Daemon mode (internal)
-  if (cmd === '_daemon') { await runDaemon(args[0]); return; }
+  if (cmd === '_browser_daemon') { await runBrowserDaemon(); return; }
 
   if (!cmd || cmd === 'help' || cmd === '--help' || cmd === '-h') {
     console.log(USAGE); process.exit(0);
   }
 
   if (cmd === 'list' || cmd === 'ls') {
-    const cdp = new CDP();
-    await cdp.connect(getWsUrl());
-    const pages = await getPages(cdp);
-    cdp.close();
-    writeFileSync(PAGES_CACHE, JSON.stringify(pages), { mode: 0o600 });
-    console.log(formatPageList(pages));
-    setTimeout(() => process.exit(0), 100);
+    const conn = await getOrStartBrowserDaemon();
+    const response = await sendCommand(conn, { cmd: 'list', args: [] });
+    if (!response.ok) { console.error('Error:', response.error); process.exit(1); }
+    // Also refresh cache via list_raw
+    const conn2 = await getOrStartBrowserDaemon();
+    const raw = await sendCommand(conn2, { cmd: 'list_raw', args: [] });
+    if (raw.ok) writeFileSync(PAGES_CACHE, raw.result, { mode: 0o600 });
+    console.log(response.result);
     return;
   }
 
-  // Open new tab
+  // Open new tab — routed through daemon to reuse existing Chrome connection
   if (cmd === 'open') {
     const url = args[0] || 'about:blank';
-    const cdp = new CDP();
-    await cdp.connect(getWsUrl());
-    const { targetId } = await cdp.send('Target.createTarget', { url });
-    // Refresh cache; new tab may not appear in getTargets immediately, so add it manually
-    const pages = await getPages(cdp);
-    if (!pages.some(p => p.targetId === targetId)) {
-      pages.push({ targetId, title: url, url });
-    }
-    cdp.close();
+    const conn = await getOrStartBrowserDaemon();
+    const response = await sendCommand(conn, { cmd: 'open', args: [url] });
+    if (!response.ok) { console.error('Error:', response.error); process.exit(1); }
+    const { targetId, pages } = JSON.parse(response.result);
     writeFileSync(PAGES_CACHE, JSON.stringify(pages), { mode: 0o600 });
     console.log(`Opened new tab: ${targetId.slice(0, 8)}  ${url}`);
-    console.log('Note: this tab will need "Allow debugging?" approval on first access.');
     return;
   }
 
   // Stop
   if (cmd === 'stop') {
-    await stopDaemons(args[0]);
+    await stopDaemon();
     return;
   }
 
@@ -845,7 +906,7 @@ async function main() {
   const pages = JSON.parse(readFileSync(PAGES_CACHE, 'utf8'));
   const targetId = resolvePrefix(targetPrefix, pages.map(p => p.targetId), 'target', 'Run "cdp list".');
 
-  const conn = await getOrStartTabDaemon(targetId);
+  const conn = await getOrStartBrowserDaemon();
 
   const cmdArgs = args.slice(1);
 
@@ -869,7 +930,7 @@ async function main() {
     process.exit(1);
   }
 
-  const response = await sendCommand(conn, { cmd, args: cmdArgs });
+  const response = await sendCommand(conn, { cmd, targetId, args: cmdArgs });
 
   if (response.ok) {
     if (response.result) console.log(response.result);


### PR DESCRIPTION
## Summary

Adds the local Chrome automation improvements we have been dogfooding:

- switches the CDP CLI to a single browser daemon so commands reuse one browser-level CDP connection
- adds `stats` for daemon health, uptime, session/page counts, recent command timings, slow commands, and last daemon-side error
- adds `inspect <target> [selector]` for a bounded, lightweight page summary before agents escalate to `snap`, `html`, or `shot`
- updates README and skill guidance so agents prefer `inspect` first and use heavier commands only when needed
- records the implementation plan in `docs/plans/2026-06-01-001-feat-cdp-observability-inspect-plan.md`

## Verification

- `node --check skills/chrome-cdp/scripts/cdp.mjs`
- `node skills/chrome-cdp/scripts/cdp.mjs stats`
- `node skills/chrome-cdp/scripts/cdp.mjs list`
- `node skills/chrome-cdp/scripts/cdp.mjs inspect <target>`
- `node skills/chrome-cdp/scripts/cdp.mjs inspect <target> h1`
- `node skills/chrome-cdp/scripts/cdp.mjs inspect <target> '#does-not-exist'`
