### PR TITLE
Add explicit CDP WebSocket URL override

### DIFF
--- a/skills/chrome-cdp/scripts/cdp.mjs
+++ b/skills/chrome-cdp/scripts/cdp.mjs
@@ -36,6 +36,13 @@ function sockPath(targetId) {
 }
 
 function getWsUrl() {
+  const configuredWsUrl = process.env.CDP_WS_URL?.trim();
+  if (configuredWsUrl) {
+    if (!/^wss?:\/\//.test(configuredWsUrl)) {
+      throw new Error('CDP_WS_URL must start with ws:// or wss://');
+    }
+    return configuredWsUrl;
+  }
   const home = homedir();
   // macOS: ~/Library/Application Support/<name>/DevToolsActivePort
   const macBrowsers = [
@@ -723,6 +730,8 @@ async function stopDaemons(targetPrefix) {
 const USAGE = `cdp - lightweight Chrome DevTools Protocol CLI (no Puppeteer)
 
 Usage: cdp <command> [args]
+
+  CDP_WS_URL=ws://...                  Optional explicit Chrome DevTools WebSocket URL
 
   list                              List open pages (shows unique target prefixes)
   snap  <target>                    Accessibility tree snapshot


### PR DESCRIPTION
## Summary

- prefer `CDP_WS_URL` when provided
- validate `ws://` and `wss://` schemes
- keep automatic DevToolsActivePort discovery as the fallback
- document the override in CLI help

## Verification

- `node --check skills/chrome-cdp/scripts/cdp.mjs`
- live `cdp list` and `cdp eval` against a Chrome CDP WebSocket

This is backward-compatible: existing discovery is unchanged when `CDP_WS_URL` is unset.